### PR TITLE
Drop parse error for missing </caption> end tag

### DIFF
--- a/src/nu/validator/htmlparser/impl/TreeBuilder.java
+++ b/src/nu/validator/htmlparser/impl/TreeBuilder.java
@@ -2029,9 +2029,10 @@ public abstract class TreeBuilder<T> implements TokenHandler,
                         case TBODY_OR_THEAD_OR_TFOOT:
                         case TR:
                         case TD_OR_TH:
-                            errStrayStartTag(name);
                             eltPos = findLastInTableScope("caption");
                             if (eltPos == TreeBuilder.NOT_FOUND_ON_STACK) {
+                                assert fragment || isTemplateContents();
+                                errStrayStartTag(name);
                                 break starttagloop;
                             }
                             generateImpliedEndTags();
@@ -3520,9 +3521,11 @@ public abstract class TreeBuilder<T> implements TokenHandler,
                             mode = IN_TABLE;
                             break endtagloop;
                         case TABLE:
-                            errTableClosedWhileCaptionOpen();
                             eltPos = findLastInTableScope("caption");
+
                             if (eltPos == TreeBuilder.NOT_FOUND_ON_STACK) {
+                                assert fragment || isTemplateContents();
+                                errStrayEndTag(name);
                                 break endtagloop;
                             }
                             generateImpliedEndTags();
@@ -6659,10 +6662,6 @@ public abstract class TreeBuilder<T> implements TokenHandler,
         }
         errNoCheck("HTML start tag \u201C" + name
                 + "\u201D in a foreign namespace context.");
-    }
-
-    private void errTableClosedWhileCaptionOpen() throws SAXException {
-        err("\u201Ctable\u201D closed but \u201Ccaption\u201D was still open.");
     }
 
     private void errNoTableRowToClose() throws SAXException {


### PR DESCRIPTION
See https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-incaption:stack-of-open-elements-2
The parse error for this case was dropped from the spec in
https://github.com/whatwg/html/commit/759ee62

Relates to https://github.com/validator/validator/issues/593
and https://bugzilla.mozilla.org/show_bug.cgi?id=1429415