### PR TITLE
Ensure every Locator is also a Locator2

### DIFF
--- a/src/nu/validator/htmlparser/impl/LocatorImpl.java
+++ b/src/nu/validator/htmlparser/impl/LocatorImpl.java
@@ -24,12 +24,15 @@
 package nu.validator.htmlparser.impl;
 
 import org.xml.sax.Locator;
+import org.xml.sax.ext.Locator2;
 
-public class LocatorImpl implements Locator {
+public class LocatorImpl implements Locator, Locator2 {
 
     private final String systemId;
 
     private final String publicId;
+
+    private final String encoding;
 
     private final int column;
 
@@ -40,6 +43,7 @@ public class LocatorImpl implements Locator {
         this.publicId = locator.getPublicId();
         this.column = locator.getColumnNumber();
         this.line = locator.getLineNumber();
+        this.encoding = ((Locator2)locator).getEncoding();
     }
 
     public final int getColumnNumber() {
@@ -56,5 +60,13 @@ public class LocatorImpl implements Locator {
 
     public final String getSystemId() {
         return systemId;
+    }
+
+    public final String getXMLVersion() {
+        return "1.0";
+    }
+
+    public final String getEncoding() {
+        return encoding;
     }
 }

--- a/src/nu/validator/htmlparser/impl/LocatorImpl.java
+++ b/src/nu/validator/htmlparser/impl/LocatorImpl.java
@@ -38,12 +38,24 @@ public class LocatorImpl implements Locator, Locator2 {
 
     private final int line;
 
+    /**
+     * Create a new Locator with default values
+     */
+    public LocatorImpl() {
+        this.systemId = this.publicId = this.encoding = null;
+        this.column = this.line = 0;
+    }
+
     public LocatorImpl(Locator locator) {
         this.systemId = locator.getSystemId();
         this.publicId = locator.getPublicId();
         this.column = locator.getColumnNumber();
         this.line = locator.getLineNumber();
-        this.encoding = ((Locator2)locator).getEncoding();
+        if (locator instanceof Locator2) {
+            this.encoding = ((Locator2)locator).getEncoding();
+        } else {
+            this.encoding = null;
+        }
     }
 
     public final int getColumnNumber() {

--- a/src/nu/validator/htmlparser/impl/Tokenizer.java
+++ b/src/nu/validator/htmlparser/impl/Tokenizer.java
@@ -37,6 +37,7 @@ package nu.validator.htmlparser.impl;
 
 import org.xml.sax.ErrorHandler;
 import org.xml.sax.Locator;
+import org.xml.sax.ext.Locator2;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 
@@ -66,7 +67,7 @@ import nu.validator.htmlparser.common.XmlViolationPolicy;
  * @version $Id$
  * @author hsivonen
  */
-public class Tokenizer implements Locator {
+public class Tokenizer implements Locator, Locator2 {
 
     private static final int DATA_AND_RCDATA_MASK = ~1;
 
@@ -872,6 +873,24 @@ public class Tokenizer implements Locator {
      */
     public String getSystemId() {
         return systemId;
+    }
+
+    /**
+     * @see org.xml.sax.ext.Locator2#getXMLVersion()
+     */
+    public String getXMLVersion() {
+        return "1.0";
+    }
+
+    /**
+     * @see org.xml.sax.ext.Locator2#getXMLVersion()
+     */
+    public String getEncoding() {
+        try {
+            return encodingDeclarationHandler == null ? null : encodingDeclarationHandler.getCharacterEncoding();
+        } catch (SAXException e) {
+            return null;
+        }
     }
 
     // end Locator impl

--- a/src/nu/validator/htmlparser/io/Driver.java
+++ b/src/nu/validator/htmlparser/io/Driver.java
@@ -579,7 +579,7 @@ public class Driver implements EncodingDeclarationHandler {
     }
 
     public String getCharacterEncoding() throws SAXException {
-        return characterEncoding.getCanonName();
+        return characterEncoding == null ? null : characterEncoding.getCanonName();
     }
 
     public Locator getDocumentLocator() {

--- a/src/nu/validator/htmlparser/io/HtmlInputStreamReader.java
+++ b/src/nu/validator/htmlparser/io/HtmlInputStreamReader.java
@@ -43,6 +43,7 @@ import nu.validator.htmlparser.impl.Tokenizer;
 
 import org.xml.sax.ErrorHandler;
 import org.xml.sax.Locator;
+import org.xml.sax.ext.Locator2;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 
@@ -59,7 +60,7 @@ import org.xml.sax.SAXParseException;
  * @author hsivonen
  */
 public final class HtmlInputStreamReader extends Reader implements
-        ByteReadable, Locator {
+        ByteReadable, Locator, Locator2 {
 
     private static final int SNIFFING_LIMIT = 1024;
 
@@ -449,6 +450,20 @@ public final class HtmlInputStreamReader extends Reader implements
     public String getSystemId() {
         if (tokenizer != null) {
             return tokenizer.getSystemId();
+        }
+        return null;
+    }
+
+    public String getXMLVersion() {
+        if (tokenizer != null) {
+            return tokenizer.getXMLVersion();
+        }
+        return null;
+    }
+
+    public String getEncoding() {
+        if (tokenizer != null) {
+            return tokenizer.getEncoding();
         }
         return null;
     }

--- a/src/nu/validator/htmlparser/io/MetaSniffer.java
+++ b/src/nu/validator/htmlparser/io/MetaSniffer.java
@@ -30,10 +30,11 @@ import nu.validator.htmlparser.impl.MetaScanner;
 
 import org.xml.sax.ErrorHandler;
 import org.xml.sax.Locator;
+import org.xml.sax.ext.Locator2;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 
-public class MetaSniffer extends MetaScanner implements Locator {
+public class MetaSniffer extends MetaScanner implements Locator, Locator2 {
     
     private Encoding characterEncoding = null;
 
@@ -139,6 +140,20 @@ public class MetaSniffer extends MetaScanner implements Locator {
     public String getSystemId() {
         if (locator != null) {
             return locator.getSystemId();
+        }
+        return null;
+    }
+
+    public String getXMLVersion() {
+        if (locator != null) {
+            return ((Locator2)locator).getXMLVersion();
+        }
+        return null;
+    }
+
+    public String getEncoding() {
+        if (locator != null) {
+            return ((Locator2)locator).getEncoding();
         }
         return null;
     }

--- a/src/nu/validator/saxtree/DocumentFragment.java
+++ b/src/nu/validator/saxtree/DocumentFragment.java
@@ -23,7 +23,7 @@
 
 package nu.validator.saxtree;
 
-import org.xml.sax.helpers.LocatorImpl;
+import nu.validator.htmlparser.impl.LocatorImpl;
 
 /**
  * A document fragment.

--- a/src/nu/validator/saxtree/LocatorImpl.java
+++ b/src/nu/validator/saxtree/LocatorImpl.java
@@ -24,13 +24,14 @@
 package nu.validator.saxtree;
 
 import org.xml.sax.Locator;
+import org.xml.sax.ext.Locator2;
 
 /**
  * A locator implementation.
  * @version $Id$
  * @author hsivonen
  */
-public final class LocatorImpl implements Locator {
+public final class LocatorImpl implements Locator, Locator2 {
 
     /**
      * The system id.
@@ -41,6 +42,11 @@ public final class LocatorImpl implements Locator {
      * The public id.
      */
     private final String publicId;
+    
+    /**
+     * The encoding.
+     */
+    private final String encoding;
     
     /**
      * The column.
@@ -62,11 +68,13 @@ public final class LocatorImpl implements Locator {
             this.publicId = null;
             this.column = -1;
             this.line = -1;
+            this.encoding = null;
         } else {
             this.systemId = locator.getSystemId();
             this.publicId = locator.getPublicId();
             this.column = locator.getColumnNumber();
             this.line = locator.getLineNumber();
+            this.encoding = ((Locator2)locator).getEncoding();
         }
     }
     
@@ -101,4 +109,21 @@ public final class LocatorImpl implements Locator {
     public String getSystemId() {
         return systemId;
     }
+
+    /**
+     * 
+     * @see org.xml.sax.ext.Locator2#getXMLVersion()
+     */
+    public String getXMLVersion() {
+        return "1.0";
+    }
+
+    /**
+     * 
+     * @see org.xml.sax.ext.Locator2#getEncoding()
+     */
+    public String getEncoding() {
+        return encoding;
+    }
+
 }

--- a/src/nu/validator/saxtree/LocatorImpl.java
+++ b/src/nu/validator/saxtree/LocatorImpl.java
@@ -74,7 +74,11 @@ public final class LocatorImpl implements Locator, Locator2 {
             this.publicId = locator.getPublicId();
             this.column = locator.getColumnNumber();
             this.line = locator.getLineNumber();
-            this.encoding = ((Locator2)locator).getEncoding();
+            if (locator instanceof Locator2) {
+                this.encoding = ((Locator2)locator).getEncoding();
+            } else {
+                this.encoding = null;
+            }
         }
     }
     

--- a/src/nu/validator/saxtree/Node.java
+++ b/src/nu/validator/saxtree/Node.java
@@ -89,7 +89,11 @@ public abstract class Node implements Locator, Locator2 {
             this.publicId = locator.getPublicId();
             this.column = locator.getColumnNumber();
             this.line = locator.getLineNumber();
-            this.encoding = ((Locator2)locator).getEncoding();
+            if (locator instanceof Locator2) {
+                this.encoding = ((Locator2)locator).getEncoding();
+            } else {
+                this.encoding = null;
+            }
         }
     }
     

--- a/src/nu/validator/saxtree/Node.java
+++ b/src/nu/validator/saxtree/Node.java
@@ -27,6 +27,7 @@ import java.util.List;
 
 import org.xml.sax.Attributes;
 import org.xml.sax.Locator;
+import org.xml.sax.ext.Locator2;
 import org.xml.sax.SAXException;
 
 /**
@@ -34,7 +35,7 @@ import org.xml.sax.SAXException;
  * @version $Id$
  * @author hsivonen
  */
-public abstract class Node implements Locator {
+public abstract class Node implements Locator, Locator2 {
 
     /**
      * The system id.
@@ -45,6 +46,11 @@ public abstract class Node implements Locator {
      * The public id.
      */
     private final String publicId;
+
+    /**
+     * The encoding.
+     */
+    private final String encoding;
     
     /**
      * The column.
@@ -75,6 +81,7 @@ public abstract class Node implements Locator {
         if (locator == null) {
             this.systemId = null;
             this.publicId = null;
+            this.encoding = null;
             this.column = -1;
             this.line = -1;
         } else {
@@ -82,6 +89,7 @@ public abstract class Node implements Locator {
             this.publicId = locator.getPublicId();
             this.column = locator.getColumnNumber();
             this.line = locator.getLineNumber();
+            this.encoding = ((Locator2)locator).getEncoding();
         }
     }
     
@@ -115,6 +123,20 @@ public abstract class Node implements Locator {
      */
     public String getSystemId() {
         return systemId;
+    }
+
+    /**
+     * @see org.xml.sax.ext.Locator2#getXMLVersion()
+     */
+    public String getXMLVersion() {
+        return "1.0";
+    }
+
+    /**
+     * @see org.xml.sax.ext.Locator2#getEncoding
+     */
+    public String getEncoding() {
+        return encoding;
     }
 
     /**

--- a/src/nu/validator/saxtree/TreeParser.java
+++ b/src/nu/validator/saxtree/TreeParser.java
@@ -303,7 +303,7 @@ public final class TreeParser implements Locator, Locator2 {
      * @see org.xml.sax.Locator#getSystemId()
      */
     public String getXMLVersion() {
-        if (locatorDelegate == null) {
+        if (!(locatorDelegate instanceof Locator2)) {
             return null;
         } else {
             return ((Locator2)locatorDelegate).getXMLVersion();
@@ -314,7 +314,7 @@ public final class TreeParser implements Locator, Locator2 {
      * @see org.xml.sax.Locator#getSystemId()
      */
     public String getEncoding() {
-        if (locatorDelegate == null) {
+        if (!(locatorDelegate instanceof Locator2)) {
             return null;
         } else {
             return ((Locator2)locatorDelegate).getEncoding();

--- a/src/nu/validator/saxtree/TreeParser.java
+++ b/src/nu/validator/saxtree/TreeParser.java
@@ -26,6 +26,7 @@ package nu.validator.saxtree;
 import org.xml.sax.Attributes;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.Locator;
+import org.xml.sax.ext.Locator2;
 import org.xml.sax.SAXException;
 import org.xml.sax.ext.LexicalHandler;
 
@@ -34,7 +35,7 @@ import org.xml.sax.ext.LexicalHandler;
  * @version $Id$
  * @author hsivonen
  */
-public final class TreeParser implements Locator {
+public final class TreeParser implements Locator, Locator2 {
     
     /**
      * The content handler.
@@ -283,7 +284,6 @@ public final class TreeParser implements Locator {
         if (locatorDelegate == null) {
             return null;
         } else {
-
             return locatorDelegate.getPublicId();
         }
     }
@@ -296,6 +296,28 @@ public final class TreeParser implements Locator {
             return null;
         } else {
             return locatorDelegate.getSystemId();
+        }
+    }
+
+    /**
+     * @see org.xml.sax.Locator#getSystemId()
+     */
+    public String getXMLVersion() {
+        if (locatorDelegate == null) {
+            return null;
+        } else {
+            return ((Locator2)locatorDelegate).getXMLVersion();
+        }
+    }
+
+    /**
+     * @see org.xml.sax.Locator#getSystemId()
+     */
+    public String getEncoding() {
+        if (locatorDelegate == null) {
+            return null;
+        } else {
+            return ((Locator2)locatorDelegate).getEncoding();
         }
     }
 }


### PR DESCRIPTION
This pull request will ensure every org.xml.sax.Locator created by this package  also implements org.xml.sax.ext.Locator2. This extended interface (added in Java 5) allows you to retrieve the encoding of the InputSource.

The encoding is important, as it's the default encoding used for CSS imports, and as the HtmlParser will sniff the encoding from an embedded `<meta charset>` element, it can't easily be retrieved any other way.

The PR casts Locator to Locator2 in many places, but as every class that implements Locator in this package also implements Locator2, this is safe.