### PR TITLE
Don’t make COMMENT_LESSTHAN transition to itself

### DIFF
--- a/src/nu/validator/htmlparser/impl/Tokenizer.java
+++ b/src/nu/validator/htmlparser/impl/Tokenizer.java
@@ -2853,8 +2853,7 @@ public class Tokenizer implements Locator, Locator2 {
                                 continue stateloop;
                             case '<':
                                 appendStrBuf(c);
-                                state = transition(state, Tokenizer.COMMENT_LESSTHAN, reconsume, pos);
-                                continue stateloop;
+                                continue;
                             case '-':
                                 appendStrBuf(c);
                                 state = transition(state, Tokenizer.COMMENT_END_DASH, reconsume, pos);
@@ -2867,13 +2866,14 @@ public class Tokenizer implements Locator, Locator2 {
                                 continue;
                             case '\u0000':
                                 c = '\uFFFD';
-                                // fall thru
+                                // CPPONLY: MOZ_FALLTHROUGH;
                             default:
                                 appendStrBuf(c);
                                 state = transition(state, Tokenizer.COMMENT, reconsume, pos);
                                 continue stateloop;
                         }
                     }
+                    // CPPONLY: MOZ_FALLTHROUGH;
                 case COMMENT_LESSTHAN_BANG:
                     for (;;) {
                         if (++pos == endPos) {
@@ -2897,13 +2897,14 @@ public class Tokenizer implements Locator, Locator2 {
                                 continue;
                             case '\u0000':
                                 c = '\uFFFD';
-                                // fall thru
+                                // CPPONLY: MOZ_FALLTHROUGH;
                             default:
                                 appendStrBuf(c);
                                 state = transition(state, Tokenizer.COMMENT, reconsume, pos);
                                 continue stateloop;
                         }
                     }
+                    // CPPONLY: MOZ_FALLTHROUGH;
                 case COMMENT_LESSTHAN_BANG_DASH:
                     for (;;) {
                         if (++pos == endPos) {
@@ -2927,13 +2928,14 @@ public class Tokenizer implements Locator, Locator2 {
                                 continue;
                             case '\u0000':
                                 c = '\uFFFD';
-                                // fall thru
+                                // CPPONLY: MOZ_FALLTHROUGH;
                             default:
                                 appendStrBuf(c);
                                 state = transition(state, Tokenizer.COMMENT, reconsume, pos);
                                 continue stateloop;
                         }
                     }
+                    // CPPONLY: MOZ_FALLTHROUGH;
                 case COMMENT_LESSTHAN_BANG_DASH_DASH:
                     for (;;) {
                         if (++pos == endPos) {
@@ -2966,7 +2968,7 @@ public class Tokenizer implements Locator, Locator2 {
                                 continue;
                             case '\u0000':
                                 c = '\uFFFD';
-                                // fall thru
+                                // CPPONLY: MOZ_FALLTHROUGH;
                             case '!':
                                 errNestedComment();
                                 adjustDoubleHyphenAndAppendToStrBufAndErr(c, reportedConsecutiveHyphens);
@@ -2981,6 +2983,7 @@ public class Tokenizer implements Locator, Locator2 {
                                 continue stateloop;
                         }
                     }
+                    // CPPONLY: MOZ_FALLTHROUGH;
                     // XXX reorder point
                 case COMMENT_START_DASH:
                     if (++pos == endPos) {


### PR DESCRIPTION
This change drops the `COMMENT_LESSTHAN` state transition from the `COMMENT_LESSTHAN` itself — since we don’t need to have the state transitioning to itself.

The change also adds `CPPONLY: MOZ_FALLTHROUGH` in some appropriate places.