### PR TITLE
Limit ambiguous-ampersand wasteful buffering

### DIFF
--- a/src/nu/validator/htmlparser/impl/Tokenizer.java
+++ b/src/nu/validator/htmlparser/impl/Tokenizer.java
@@ -3536,7 +3536,13 @@ public class Tokenizer implements Locator, Locator2 {
                         } else if ((c >= '0' && c <= '9')
                                 || (c >= 'A' && c <= 'Z')
                                 || (c >= 'a' && c <= 'z')) {
-                            appendStrBuf(c);
+                            if (returnState == ATTRIBUTE_VALUE_DOUBLE_QUOTED
+                                    || returnState == ATTRIBUTE_VALUE_SINGLE_QUOTED
+                                    || returnState == ATTRIBUTE_VALUE_UNQUOTED) {
+                                appendStrBuf(c);
+                            }
+                            /* The following pos++ is necessary due to how we’ve
+                             * handled the "reconsume" block for this case. */
                             pos++;
                             continue;
                         }


### PR DESCRIPTION
This refines 9ce4bd4 by only buffering if we’re actually inside an attribute value.