### PR TITLE
Mozilla bug 1650066 fixup - Avoid calling errListUnclosedStartTags in C++

### DIFF
--- a/src/nu/validator/htmlparser/impl/TreeBuilder.java
+++ b/src/nu/validator/htmlparser/impl/TreeBuilder.java
@@ -1348,9 +1348,11 @@ public abstract class TreeBuilder<T> implements TokenHandler,
                         assert fragment;
                         break eofloop;
                     }
+                    // [NOCPP[
                     if (errorHandler != null) {
                         errListUnclosedStartTags(0);
                     }
+                    // ]NOCPP]
                     while (currentPtr >= eltPos) {
                         pop();
                     }


### PR DESCRIPTION
Differential Revision: https://phabricator.services.mozilla.com/D82007