### PR TITLE
Fixup for NOCPP directives for HTML4 support removal.

### DIFF
--- a/src/nu/validator/htmlparser/impl/TreeBuilder.java
+++ b/src/nu/validator/htmlparser/impl/TreeBuilder.java
@@ -731,7 +731,9 @@ public abstract class TreeBuilder<T> implements TokenHandler,
                         systemIdentifier == null ? emptyString
                                 : systemIdentifier);
                 Portability.releaseString(emptyString);
+                // [NOCPP[
             }
+            // ]NOCPP]
             if (isQuirky(name, publicIdentifier, systemIdentifier,
                     forceQuirks)) {
                 errQuirkyDoctype();


### PR DESCRIPTION
Required for https://github.com/validator/htmlparser/commit/5c8fe7adb785147d5fb819993a15afd15b666b74 to translate into C++.