### PR TITLE
Small POM fixes for 1.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,8 +69,8 @@
     </license>
   </licenses>
   <scm>
-    <connection>scm:hg:http://hg.mozilla.org/projects/htmlparser/</connection>
-    <url>http://hg.mozilla.org/projects/htmlparser/</url>
+    <connection>scm:git:https://github.com/validator/htmlparser.git</connection>
+    <url>https://github.com/validator/htmlparser</url>
   </scm>
   <build>
     <sourceDirectory>${project.build.directory}/src</sourceDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
             <Bundle-Name>${project.name}</Bundle-Name>
             <Bundle-SymbolicName>nu.validator.htmlparser</Bundle-SymbolicName>
             <Bundle-Version>${project.version}</Bundle-Version>
-            <Bundle-RequiredExecutionEnvironment>J2SE-1.5</Bundle-RequiredExecutionEnvironment>
+            <Bundle-RequiredExecutionEnvironment>JavaSE-1.7</Bundle-RequiredExecutionEnvironment>
             <Automatic-Module-Name>nu.validator.htmlparser</Automatic-Module-Name>
             <_removeheaders>Built-By,Bnd-LastModified</_removeheaders>
           </instructions>

--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,7 @@
             </goals>
             <configuration>
               <target>
+                <property name="build.compiler" value="extJavac"/>
                 <property name="translator.sources" value="${basedir}/translator-src"/>
                 <property name="translator.classes" value="${project.build.directory}/translator-classes"/>
                 <mkdir dir="${translator.classes}"/>


### PR DESCRIPTION
Two small POM updates for 1.5:

1. Update OSGi metadata for the new 1.7 environment.
2. Update `scm` information which still pointed to the old site.