### PR TITLE
Conform ambiguous-ampersand reporting to HTML spec

### DIFF
--- a/src/nu/validator/htmlparser/impl/Tokenizer.java
+++ b/src/nu/validator/htmlparser/impl/Tokenizer.java
@@ -220,6 +220,8 @@ public class Tokenizer implements Locator {
 
     public static final int PROCESSING_INSTRUCTION_QUESTION_MARK = 74;
 
+    public static final int AMBIGUOUS_AMPERSAND = 75;
+
     /**
      * Magic value for UTF-16 operations.
      */
@@ -3106,6 +3108,7 @@ public class Tokenizer implements Locator {
                         case '<':
                         case '&':
                         case '\u0000':
+                        case ';':
                             emitOrAppendCharRefBuf(returnState);
                             if ((returnState & DATA_AND_RCDATA_MASK) == 0) {
                                 cstart = pos;
@@ -3134,17 +3137,12 @@ public class Tokenizer implements Locator {
                                 firstCharKey = c - 'A';
                             } else {
                                 // No match
-                                /*
-                                 * If no match can be made, then this is a parse
-                                 * error.
-                                 */
-                                errNoNamedCharacterMatch();
                                 emitOrAppendCharRefBuf(returnState);
                                 if ((returnState & DATA_AND_RCDATA_MASK) == 0) {
                                     cstart = pos;
                                 }
                                 reconsume = true;
-                                state = transition(state, returnState, reconsume, pos);
+                                state = transition(state, Tokenizer.AMBIGUOUS_AMPERSAND, reconsume, pos);
                                 continue stateloop;
                             }
                             // Didn't fail yet
@@ -3205,17 +3203,12 @@ public class Tokenizer implements Locator {
                             }
                         }
                         if (hilo == 0) {
-                            /*
-                             * If no match can be made, then this is a parse
-                             * error.
-                             */
-                            errNoNamedCharacterMatch();
                             emitOrAppendCharRefBuf(returnState);
                             if ((returnState & DATA_AND_RCDATA_MASK) == 0) {
                                 cstart = pos;
                             }
                             reconsume = true;
-                            state = transition(state, returnState, reconsume, pos);
+                            state = transition(state, Tokenizer.AMBIGUOUS_AMPERSAND, reconsume, pos);
                             continue stateloop;
                         }
                         // Didn't fail yet
@@ -3298,16 +3291,12 @@ public class Tokenizer implements Locator {
 
                     if (candidate == -1) {
                         // reconsume deals with CR, LF or nul
-                        /*
-                         * If no match can be made, then this is a parse error.
-                         */
-                        errNoNamedCharacterMatch();
                         emitOrAppendCharRefBuf(returnState);
                         if ((returnState & DATA_AND_RCDATA_MASK) == 0) {
                             cstart = pos;
                         }
                         reconsume = true;
-                        state = transition(state, returnState, reconsume, pos);
+                        state = transition(state, Tokenizer.AMBIGUOUS_AMPERSAND, reconsume, pos);
                         continue stateloop;
                     } else {
                         // c can't be CR, LF or nul if we got here
@@ -3345,10 +3334,9 @@ public class Tokenizer implements Locator {
                                      * after the U+0026 AMPERSAND (&) must be
                                      * unconsumed, and nothing is returned.
                                      */
-                                    errNoNamedCharacterMatch();
                                     appendCharRefBufToStrBuf();
                                     reconsume = true;
-                                    state = transition(state, returnState, reconsume, pos);
+                                    state = transition(state, Tokenizer.AMBIGUOUS_AMPERSAND, reconsume, pos);
                                     continue stateloop;
                                 }
                             }
@@ -3410,6 +3398,35 @@ public class Tokenizer implements Locator {
                          * the entity would be parsed as "notin;", resulting in
                          * I'm ∉ I tell you.
                          */
+                    }
+                    // XXX reorder point
+                case AMBIGUOUS_AMPERSAND:
+                    /*
+                     * Unlike the definition is the spec, we don't consume the
+                     * next input character right away when entering this state;
+                     * that's because our current implementation differs from
+                     * the spec in that we've already consumed the relevant
+                     * character *before* entering this state.
+                     */
+                    ampersandloop: for (;;) {
+                        if (c == ';') {
+                            errNoNamedCharacterMatch();
+                        } else if ((c >= '0' && c <= '9')
+                                || (c >= 'A' && c <= 'Z')
+                                || (c >= 'a' && c <= 'z')) {
+                            emitOrAppendCharRefBuf(returnState);
+                            if ((returnState & DATA_AND_RCDATA_MASK) == 0) {
+                                cstart = pos;
+                            }
+                            if (++pos == endPos) {
+                                break stateloop;
+                            }
+                            c = checkChar(buf, pos);
+                            continue;
+                        }
+                        reconsume = true;
+                        state = transition(state, returnState, reconsume, pos);
+                        continue stateloop;
                     }
                 case CONSUME_NCR:
                     if (++pos == endPos) {
@@ -6501,7 +6518,6 @@ public class Tokenizer implements Locator {
                     state = returnState;
                     continue;
                 case CHARACTER_REFERENCE_HILO_LOOKUP:
-                    errNoNamedCharacterMatch();
                     emitOrAppendCharRefBuf(returnState);
                     state = returnState;
                     continue;
@@ -6555,10 +6571,6 @@ public class Tokenizer implements Locator {
                     }
 
                     if (candidate == -1) {
-                        /*
-                         * If no match can be made, then this is a parse error.
-                         */
-                        errNoNamedCharacterMatch();
                         emitOrAppendCharRefBuf(returnState);
                         state = returnState;
                         continue eofloop;
@@ -6596,7 +6608,6 @@ public class Tokenizer implements Locator {
                                      * after the U+0026 AMPERSAND (&) must be
                                      * unconsumed, and nothing is returned.
                                      */
-                                    errNoNamedCharacterMatch();
                                     appendCharRefBufToStrBuf();
                                     state = returnState;
                                     continue eofloop;


### PR DESCRIPTION
This is a replacement change for the previous ambiguous-ampersand attempt in the validator-nu branch. Unlike that previous attempt, this one, I think, will not have the problems the Mozilla try bot uncovered.

https://treeherder.mozilla.org/#/jobs?repo=try&selectedTaskRun=GdCS5FrVRbCXm2jscZdZkw.0&revision=59a1564