### PR TITLE
Fix ambiguous-ampersand reporting (revisions against the validator-nu branch)

### DIFF
--- a/src/nu/validator/htmlparser/impl/Tokenizer.java
+++ b/src/nu/validator/htmlparser/impl/Tokenizer.java
@@ -3546,10 +3546,9 @@ public class Tokenizer implements Locator, Locator2 {
                         } else if ((c >= '0' && c <= '9')
                                 || (c >= 'A' && c <= 'Z')
                                 || (c >= 'a' && c <= 'z')) {
-                            if (returnState == ATTRIBUTE_VALUE_DOUBLE_QUOTED
-                                    || returnState == ATTRIBUTE_VALUE_SINGLE_QUOTED
-                                    || returnState == ATTRIBUTE_VALUE_UNQUOTED) {
-                                appendStrBuf(c);
+                            emitOrAppendCharRefBuf(returnState);
+                            if ((returnState & DATA_AND_RCDATA_MASK) == 0) {
+                                cstart = pos;
                             }
                             /* The following pos++ is necessary due to how we’ve
                              * handled the "reconsume" block for this case. */

--- a/src/nu/validator/htmlparser/impl/Tokenizer.java
+++ b/src/nu/validator/htmlparser/impl/Tokenizer.java
@@ -3533,14 +3533,14 @@ public class Tokenizer implements Locator, Locator2 {
                     }
                     // XXX reorder point
                 case AMBIGUOUS_AMPERSAND:
+                    /*
+                     * Unlike the definition is the spec, we don't consume the
+                     * next input character right away when entering this state;
+                     * that's because our current implementation differs from
+                     * the spec in that we've already consumed the relevant
+                     * character *before* entering this state.
+                     */
                     ampersandloop: for (;;) {
-                        if (reconsume) {
-                            if (++pos == endPos) {
-                                break stateloop;
-                            }
-                            pos--;
-                            c = checkChar(buf, pos);
-                        }
                         if (c == ';') {
                             errNoNamedCharacterMatch();
                         } else if ((c >= '0' && c <= '9')
@@ -3550,11 +3550,13 @@ public class Tokenizer implements Locator, Locator2 {
                             if ((returnState & DATA_AND_RCDATA_MASK) == 0) {
                                 cstart = pos;
                             }
-                            /* The following pos++ is necessary due to how we’ve
-                             * handled the "reconsume" block for this case. */
-                            pos++;
+                            if (++pos == endPos) {
+                                break stateloop;
+                            }
+                            c = checkChar(buf, pos);
                             continue;
                         }
+                        reconsume = true;
                         state = transition(state, returnState, reconsume, pos);
                         continue stateloop;
                     }

--- a/src/nu/validator/htmlparser/impl/Tokenizer.java
+++ b/src/nu/validator/htmlparser/impl/Tokenizer.java
@@ -3455,6 +3455,13 @@ public class Tokenizer implements Locator, Locator2 {
                                      * LATIN CAPITAL LETTER Z, or U+0061 LATIN
                                      * SMALL LETTER A to U+007A LATIN SMALL
                                      * LETTER Z, then, for historical reasons,
+                                     * ---
+                                     * FIXME: The remainder of this comment
+                                     * doesn't actually match the current spec.
+                                     * But the code behavior here also doesn't
+                                     * match the current spec, so it's unclear
+                                     * how to reconcile it...
+                                     * ---
                                      * all the characters that were matched
                                      * after the U+0026 AMPERSAND (&) must be
                                      * unconsumed, and nothing is returned.


### PR DESCRIPTION
This PR is just for review purposes only. It shows the incremental updates fixes made to the existing (broken) ambiguous-ampersand fix on the validator-nu branch.

https://github.com/validator/htmlparser/pull/27 has a single unified (squashed) fix, suitable for (eventually) merging to master (and into the Firefox code).