### PR TITLE
Conform ambiguous-ampersand reporting to HTML spec

### DIFF
--- a/src/nu/validator/htmlparser/impl/Tokenizer.java
+++ b/src/nu/validator/htmlparser/impl/Tokenizer.java
@@ -3355,26 +3355,29 @@ public class Tokenizer implements Locator, Locator2 {
                      * that's because our current implementation differs from
                      * the spec in that we've already consumed the relevant
                      * character *before* entering this state.
+                     * Also, our implementation of this state has no looping.
+                     * So we never stay in this state; instead, we always
+                     * transition out from it back to returnState.
                      */
                     state = returnState;
-                        if (c == ';') {
-                            errNoNamedCharacterMatch();
-                            continue stateloop;
-                        } else if ((c >= '0' && c <= '9')
-                                || (c >= 'A' && c <= 'Z')
-                                || (c >= 'a' && c <= 'z')) {
-                            appendCharRefBuf(c);
-                            emitOrAppendCharRefBuf(returnState);
-                            if ((returnState & DATA_AND_RCDATA_MASK) == 0) {
-                                cstart = pos + 1;
-                            }
-                            if (++pos == endPos) {
-                                break stateloop;
-                            }
-                            c = checkChar(buf, pos);
-                            continue stateloop;
-                        }
+                    if (c == ';') {
+                        errNoNamedCharacterMatch();
                         continue stateloop;
+                    } else if ((c >= '0' && c <= '9')
+                            || (c >= 'A' && c <= 'Z')
+                            || (c >= 'a' && c <= 'z')) {
+                        appendCharRefBuf(c);
+                        emitOrAppendCharRefBuf(returnState);
+                        if ((returnState & DATA_AND_RCDATA_MASK) == 0) {
+                            cstart = pos + 1;
+                        }
+                        if (++pos == endPos) {
+                            break stateloop;
+                        }
+                        c = checkChar(buf, pos);
+                        continue stateloop;
+                    }
+                    continue stateloop;
                 case CONSUME_NCR:
                     if (++pos == endPos) {
                         break stateloop;

--- a/src/nu/validator/htmlparser/impl/Tokenizer.java
+++ b/src/nu/validator/htmlparser/impl/Tokenizer.java
@@ -3356,9 +3356,10 @@ public class Tokenizer implements Locator, Locator2 {
                      * the spec in that we've already consumed the relevant
                      * character *before* entering this state.
                      */
-                    ampersandloop: for (;;) {
+                    state = returnState;
                         if (c == ';') {
                             errNoNamedCharacterMatch();
+                            continue stateloop;
                         } else if ((c >= '0' && c <= '9')
                                 || (c >= 'A' && c <= 'Z')
                                 || (c >= 'a' && c <= 'z')) {
@@ -3371,14 +3372,9 @@ public class Tokenizer implements Locator, Locator2 {
                                 break stateloop;
                             }
                             c = checkChar(buf, pos);
-                            continue;
+                            continue stateloop;
                         }
-                        if ((returnState & DATA_AND_RCDATA_MASK) == 0) {
-                            reconsume = true;
-                        }
-                        state = transition(state, returnState, reconsume, pos);
                         continue stateloop;
-                    }
                 case CONSUME_NCR:
                     if (++pos == endPos) {
                         break stateloop;

--- a/src/nu/validator/htmlparser/impl/Tokenizer.java
+++ b/src/nu/validator/htmlparser/impl/Tokenizer.java
@@ -3362,18 +3362,17 @@ public class Tokenizer implements Locator, Locator2 {
                         } else if ((c >= '0' && c <= '9')
                                 || (c >= 'A' && c <= 'Z')
                                 || (c >= 'a' && c <= 'z')) {
-                            if (++pos == endPos) {
-                                break stateloop;
-                            }
                             appendCharRefBuf(c);
                             emitOrAppendCharRefBuf(returnState);
                             if ((returnState & DATA_AND_RCDATA_MASK) == 0) {
-                                cstart = pos;
+                                cstart = pos + 1;
+                            }
+                            if (++pos == endPos) {
+                                break stateloop;
                             }
                             c = checkChar(buf, pos);
                             continue;
                         }
-                        reconsume = true;
                         state = transition(state, returnState, reconsume, pos);
                         continue stateloop;
                     }

--- a/src/nu/validator/htmlparser/impl/Tokenizer.java
+++ b/src/nu/validator/htmlparser/impl/Tokenizer.java
@@ -3373,6 +3373,9 @@ public class Tokenizer implements Locator, Locator2 {
                             c = checkChar(buf, pos);
                             continue;
                         }
+                        if ((returnState & DATA_AND_RCDATA_MASK) == 0) {
+                            reconsume = true;
+                        }
                         state = transition(state, returnState, reconsume, pos);
                         continue stateloop;
                     }

--- a/src/nu/validator/htmlparser/impl/Tokenizer.java
+++ b/src/nu/validator/htmlparser/impl/Tokenizer.java
@@ -221,6 +221,8 @@ public class Tokenizer implements Locator, Locator2 {
 
     public static final int PROCESSING_INSTRUCTION_QUESTION_MARK = 74;
 
+    public static final int AMBIGUOUS_AMPERSAND = 75;
+
     /**
      * Magic value for UTF-16 operations.
      */
@@ -3054,6 +3056,7 @@ public class Tokenizer implements Locator, Locator2 {
                         case '<':
                         case '&':
                         case '\u0000':
+                        case ';':
                             emitOrAppendCharRefBuf(returnState);
                             if ((returnState & DATA_AND_RCDATA_MASK) == 0) {
                                 cstart = pos;
@@ -3082,17 +3085,12 @@ public class Tokenizer implements Locator, Locator2 {
                                 firstCharKey = c - 'A';
                             } else {
                                 // No match
-                                /*
-                                 * If no match can be made, then this is a parse
-                                 * error.
-                                 */
-                                errNoNamedCharacterMatch();
                                 emitOrAppendCharRefBuf(returnState);
                                 if ((returnState & DATA_AND_RCDATA_MASK) == 0) {
                                     cstart = pos;
                                 }
                                 reconsume = true;
-                                state = transition(state, returnState, reconsume, pos);
+                                state = transition(state, Tokenizer.AMBIGUOUS_AMPERSAND, reconsume, pos);
                                 continue stateloop;
                             }
                             // Didn't fail yet
@@ -3153,17 +3151,12 @@ public class Tokenizer implements Locator, Locator2 {
                             }
                         }
                         if (hilo == 0) {
-                            /*
-                             * If no match can be made, then this is a parse
-                             * error.
-                             */
-                            errNoNamedCharacterMatch();
                             emitOrAppendCharRefBuf(returnState);
                             if ((returnState & DATA_AND_RCDATA_MASK) == 0) {
                                 cstart = pos;
                             }
                             reconsume = true;
-                            state = transition(state, returnState, reconsume, pos);
+                            state = transition(state, Tokenizer.AMBIGUOUS_AMPERSAND, reconsume, pos);
                             continue stateloop;
                         }
                         // Didn't fail yet
@@ -3246,16 +3239,12 @@ public class Tokenizer implements Locator, Locator2 {
 
                     if (candidate == -1) {
                         // reconsume deals with CR, LF or nul
-                        /*
-                         * If no match can be made, then this is a parse error.
-                         */
-                        errNoNamedCharacterMatch();
                         emitOrAppendCharRefBuf(returnState);
                         if ((returnState & DATA_AND_RCDATA_MASK) == 0) {
                             cstart = pos;
                         }
                         reconsume = true;
-                        state = transition(state, returnState, reconsume, pos);
+                        state = transition(state, Tokenizer.AMBIGUOUS_AMPERSAND, reconsume, pos);
                         continue stateloop;
                     } else {
                         // c can't be CR, LF or nul if we got here
@@ -3293,10 +3282,9 @@ public class Tokenizer implements Locator, Locator2 {
                                      * after the U+0026 AMPERSAND (&) must be
                                      * unconsumed, and nothing is returned.
                                      */
-                                    errNoNamedCharacterMatch();
                                     appendCharRefBufToStrBuf();
                                     reconsume = true;
-                                    state = transition(state, returnState, reconsume, pos);
+                                    state = transition(state, Tokenizer.AMBIGUOUS_AMPERSAND, reconsume, pos);
                                     continue stateloop;
                                 }
                             }
@@ -3358,6 +3346,36 @@ public class Tokenizer implements Locator, Locator2 {
                          * the entity would be parsed as "notin;", resulting in
                          * I'm ∉ I tell you.
                          */
+                    }
+                    // XXX reorder point
+                case AMBIGUOUS_AMPERSAND:
+                    /*
+                     * Unlike the definition is the spec, we don't consume the
+                     * next input character right away when entering this state;
+                     * that's because our current implementation differs from
+                     * the spec in that we've already consumed the relevant
+                     * character *before* entering this state.
+                     */
+                    ampersandloop: for (;;) {
+                        if (c == ';') {
+                            errNoNamedCharacterMatch();
+                        } else if ((c >= '0' && c <= '9')
+                                || (c >= 'A' && c <= 'Z')
+                                || (c >= 'a' && c <= 'z')) {
+                            if (++pos == endPos) {
+                                break stateloop;
+                            }
+                            appendCharRefBuf(c);
+                            emitOrAppendCharRefBuf(returnState);
+                            if ((returnState & DATA_AND_RCDATA_MASK) == 0) {
+                                cstart = pos;
+                            }
+                            c = checkChar(buf, pos);
+                            continue;
+                        }
+                        reconsume = true;
+                        state = transition(state, returnState, reconsume, pos);
+                        continue stateloop;
                     }
                 case CONSUME_NCR:
                     if (++pos == endPos) {
@@ -6449,7 +6467,6 @@ public class Tokenizer implements Locator, Locator2 {
                     state = returnState;
                     continue;
                 case CHARACTER_REFERENCE_HILO_LOOKUP:
-                    errNoNamedCharacterMatch();
                     emitOrAppendCharRefBuf(returnState);
                     state = returnState;
                     continue;
@@ -6503,10 +6520,6 @@ public class Tokenizer implements Locator, Locator2 {
                     }
 
                     if (candidate == -1) {
-                        /*
-                         * If no match can be made, then this is a parse error.
-                         */
-                        errNoNamedCharacterMatch();
                         emitOrAppendCharRefBuf(returnState);
                         state = returnState;
                         continue eofloop;
@@ -6544,7 +6557,6 @@ public class Tokenizer implements Locator, Locator2 {
                                      * after the U+0026 AMPERSAND (&) must be
                                      * unconsumed, and nothing is returned.
                                      */
-                                    errNoNamedCharacterMatch();
                                     appendCharRefBufToStrBuf();
                                     state = returnState;
                                     continue eofloop;


### PR DESCRIPTION
This is another replacement change for the previous ambiguous-ampersand attempts. Unlike the previous attempts, I’ve actually run this one against the html5lib entity tests, and confirmed that it passes all.

Specifically, I ran the following:

```
java nu.validator.htmlparser.test.TokenizerTester ./html5lib-tests/tokenizer/entities.test
java nu.validator.htmlparser.test.TokenizerTester ./html5lib-tests/tokenizer/namedEntities.test

java nu.validator.htmlparser.test.TreeTester ./html5lib-tests/tree-construction/entities01.dat
java nu.validator.htmlparser.test.TreeTester ./html5lib-tests/tree-construction/entities02.dat
```

I also manually confirmed that this passes the failing tests from the trybot run at https://treeherder.mozilla.org/#/jobs?repo=try&revision=439fd78375fe4d83a5999e2e0c9d30075da4efb3&selectedTaskRun=dKhZOkS3SAqKuh4HMwuHfw.0 (which I think are actually just a subset of the html5lib tests).

So I think I can now assert with confidence that the patch in this PR:

* passes all the tests that had been failing
* doesn’t introduce any regressions in tests that had already been passing