### PR TITLE
Fix TokenizerTester casing of PCDATA state name

### DIFF
--- a/test-src/nu/validator/htmlparser/test/TokenizerTester.java
+++ b/test-src/nu/validator/htmlparser/test/TokenizerTester.java
@@ -53,7 +53,7 @@ public class TokenizerTester {
 
     private static JSONString PLAINTEXT = new JSONString("PLAINTEXT state");
 
-    private static JSONString PCDATA = new JSONString("DATA state");
+    private static JSONString PCDATA = new JSONString("Data state");
 
     private static JSONString RCDATA = new JSONString("RCDATA state");
 


### PR DESCRIPTION
This change updates the `TokenizerTester` code to expect its input test data to have the string `Data state` to identify PCDATA tests — rather than the string `DATA state`.

The test data in the html5lib-tests suite uses `Data state`, so without this change, running TokenizerTester against html5lib-tests causes `TokenizerTester` to fail with a “Broken test data” harness failure.