### PR TITLE
Make TreeTester ignore tests for keygen element

### DIFF
--- a/test-src/nu/validator/htmlparser/test/TreeTester.java
+++ b/test-src/nu/validator/htmlparser/test/TreeTester.java
@@ -213,6 +213,9 @@ public class TreeTester {
                 expectedBuilder.append((char)ch);
             }
             String expected = expectedBuilder.toString();
+            if (expected.contains("<keygen>")) {
+                return true;
+            }
             String actual = sw.toString();
 
             LinkedList<String> actualErrors = leh.getErrors();


### PR DESCRIPTION
This change makes `TreeTester` ignore any tests which have the `keygen` element in their expected results.

Otherwise, without this change, we fail the tokenizer test at https://github.com/html5lib/html5lib-tests/blob/master/tree-construction/tests7.dat#L409 due to the fact with https://github.com/validator/htmlparser/commit/8f9f6bc we completely removed `keygen` parsing support from our code. (However, the `keygen` parsing requirements are still in the HTML spec, so the test case cannot be removed from html5lib-tests.)