### PR TITLE
Ensure testharness makes missing doctype name null

### DIFF
--- a/src/nu/validator/htmlparser/impl/Tokenizer.java
+++ b/src/nu/validator/htmlparser/impl/Tokenizer.java
@@ -5942,7 +5942,7 @@ public class Tokenizer implements Locator, Locator2 {
         // Discard the characters "DOCTYPE" accumulated as a potential bogus
         // comment into strBuf.
         clearStrBufAfterUse();
-        doctypeName = "";
+        doctypeName = null;
         if (systemIdentifier != null) {
             Portability.releaseString(systemIdentifier);
             systemIdentifier = null;
@@ -6246,7 +6246,7 @@ public class Tokenizer implements Locator, Locator2 {
                          * Create a new DOCTYPE token. Set its force-quirks flag
                          * to on.
                          */
-                        doctypeName = "";
+                        doctypeName = null;
                         if (systemIdentifier != null) {
                             Portability.releaseString(systemIdentifier);
                             systemIdentifier = null;

--- a/test-src/nu/validator/htmlparser/test/JSONArrayTokenHandler.java
+++ b/test-src/nu/validator/htmlparser/test/JSONArrayTokenHandler.java
@@ -94,7 +94,7 @@ public class JSONArrayTokenHandler implements TokenHandler, ErrorHandler {
         flushCharacters();
         JSONArray token = new JSONArray();
         token.getValue().add(DOCTYPE);
-        token.getValue().add(new JSONString(name));
+        token.getValue().add(name == null ? JSONNull.NULL : new JSONString(name));
         token.getValue().add(publicIdentifier == null ? JSONNull.NULL : new JSONString(publicIdentifier));
         token.getValue().add(systemIdentifier == null ? JSONNull.NULL : new JSONString(systemIdentifier));
         token.getValue().add(new JSONBoolean(!forceQuirks));


### PR DESCRIPTION
This change ensures that the tokenizer sets the doctype name to null when the doctype name is missing in the input source.

Otherwise, without this change, the doctype name is set to the empty string — which doesn’t conform to the requirements in the HTML spec, and which causes us to fail 9 tests in the html5lib-tests suite.

This PR branch also includes a related change for the testharness.

Relates to https://github.com/validator/htmlparser/issues/35

--- 

The tests that are failing without this change are the following:

* https://github.com/html5lib/html5lib-tests/blob/master/tokenizer/test2.test#L3 (“DOCTYPE without name”)
* https://github.com/html5lib/html5lib-tests/blob/master/tokenizer/test3.test#L1956 (`<!DOCTYPE\\u0009`)
* https://github.com/html5lib/html5lib-tests/blob/master/tokenizer/test3.test#L1963 (`<!DOCTYPE\\u000A`)
* https://github.com/html5lib/html5lib-tests/blob/master/tokenizer/test3.test#L1970 (`<!DOCTYPE\\u000B`)
* https://github.com/html5lib/html5lib-tests/blob/master/tokenizer/test3.test#L1979 (`<!DOCTYPE\\u000C`)
* https://github.com/html5lib/html5lib-tests/blob/master/tokenizer/test3.test#L1986 (`<!DOCTYPE\\u000D`)
* https://github.com/html5lib/html5lib-tests/blob/master/tokenizer/test3.test#L2069 (`<!DOCTYPE  `)
* https://github.com/html5lib/html5lib-tests/blob/master/tokenizer/test3.test#L2153 (`<!DOCTYPE >`)
* https://github.com/html5lib/html5lib-tests/blob/master/tokenizer/test3.test#L5273 (`<!DOCTYPE>`)