### PR TITLE
Make io.Driver expose public dontSwallowBom(), and use it in the testharness

### DIFF
--- a/src/nu/validator/htmlparser/io/Driver.java
+++ b/src/nu/validator/htmlparser/io/Driver.java
@@ -59,7 +59,7 @@ public class Driver implements EncodingDeclarationHandler {
      */
     private RewindableInputStream rewindableInputStream;
 
-    private boolean swallowBom;
+    private boolean swallowBom = true;
 
     private Encoding characterEncoding;
 
@@ -178,7 +178,6 @@ public class Driver implements EncodingDeclarationHandler {
         }
         tokenizer.start();
         confidence = Confidence.TENTATIVE;
-        swallowBom = true;
         rewindableInputStream = null;
         tokenizer.initLocation(is.getPublicId(), is.getSystemId());
         this.reader = is.getCharacterStream();
@@ -266,7 +265,7 @@ public class Driver implements EncodingDeclarationHandler {
         }
     }
 
-    void dontSwallowBom() {
+    public void dontSwallowBom() {
         swallowBom = false;
     }
 

--- a/test-src/nu/validator/htmlparser/test/TokenizerTester.java
+++ b/test-src/nu/validator/htmlparser/test/TokenizerTester.java
@@ -105,6 +105,7 @@ public class TokenizerTester {
         driver.setNamePolicy(XmlViolationPolicy.ALLOW);
         driver.setXmlnsPolicy(XmlViolationPolicy.ALLOW);
         driver.setErrorHandler(tokenHandler);
+        driver.dontSwallowBom();
         writer = new OutputStreamWriter(System.out, "UTF-8");
         JSONParser jsonParser = new JSONParser(new InputStreamReader(stream,
                 "UTF-8"));


### PR DESCRIPTION
This change makes `nu.validator.htmlparser.io.Driver` instances have a `dontSwallowBom()` method exposed.

Otherwise, without this change, it’s not possible for users of `io.Driver` to preserve the BOM in input.

This PR branch also has a related change for the testharness. Without that change, the following html5lib-tests case fails:

* https://github.com/html5lib/html5lib-tests/blob/master/tokenizer/domjs.test#L197 (“leading U+FEFF must pass through”)