### PR TITLE
Set default lastStartTag in TokenizerTester

### DIFF
--- a/test-src/nu/validator/htmlparser/test/TokenizerTester.java
+++ b/test-src/nu/validator/htmlparser/test/TokenizerTester.java
@@ -140,18 +140,23 @@ public class TokenizerTester {
         } else {
             for (JSONValue value : contentModelFlags.getValue()) {
                 if (PCDATA.equals(value)) {
+                    lastStartTag = lastStartTag == null ? "xmp" : lastStartTag;
                     runTestInner(inputString, expectedTokens, description,
                             Tokenizer.DATA, lastStartTag);
                 } else if (RAWTEXT.equals(value)) {
+                    lastStartTag = lastStartTag == null ? "xmp" : lastStartTag;
                     runTestInner(inputString, expectedTokens, description,
                             Tokenizer.RAWTEXT, lastStartTag);
                 } else if (RCDATA.equals(value)) {
+                    lastStartTag = lastStartTag == null ? "xmp" : lastStartTag;
                     runTestInner(inputString, expectedTokens, description,
                             Tokenizer.RCDATA, lastStartTag);
                 } else if (CDATA.equals(value)) {
+                    lastStartTag = lastStartTag == null ? "xmp" : lastStartTag;
                     runTestInner(inputString, expectedTokens, description,
                             Tokenizer.CDATA_SECTION, lastStartTag);
                 } else if (PLAINTEXT.equals(value)) {
+                    lastStartTag = lastStartTag == null ? "plaintext" : lastStartTag;
                     runTestInner(inputString, expectedTokens, description,
                             Tokenizer.PLAINTEXT, lastStartTag);
                 } else if (SCRIPT_DATA.equals(value)) {


### PR DESCRIPTION
This change causes `TokenizerTester` to set a default `lastStartTag` value for any test which has a `initialStates` value but no `lastStartTag` value.

Otherwise, without this change, the tokenizer is never actually run for such missing-`lastStartTag` tests — which results in us failing 5 tests from the html5lib-tests suite.

---

The html5lib-tests cases which fail without this change are the following:

* https://github.com/html5lib/html5lib-tests/blob/master/tokenizer/domjs.test#L28 (“Raw NUL replacement”)
* https://github.com/html5lib/html5lib-tests/blob/master/tokenizer/domjs.test#L38 (“NUL in CDATA section”)
* https://github.com/html5lib/html5lib-tests/blob/master/tokenizer/domjs.test#L284 (“CDATA content”)
* https://github.com/html5lib/html5lib-tests/blob/master/tokenizer/domjs.test#L290 (“CDATA followed by HTML content“)
* https://github.com/html5lib/html5lib-tests/blob/master/tokenizer/domjs.test#L296 (“CDATA with extra bracket”)