### PR TITLE
testharness: Use the correct lastStartTag value when running tests with “Script data state” as the initial state

### DIFF
--- a/test-src/nu/validator/htmlparser/test/TokenizerTester.java
+++ b/test-src/nu/validator/htmlparser/test/TokenizerTester.java
@@ -155,8 +155,9 @@ public class TokenizerTester {
                     runTestInner(inputString, expectedTokens, description,
                             Tokenizer.PLAINTEXT, lastStartTag);
                 } else if (SCRIPT_DATA.equals(value)) {
+                    lastStartTag = lastStartTag == null ? "script" : lastStartTag;
                     runTestInner(inputString, expectedTokens, description,
-                            Tokenizer.SCRIPT_DATA, "script");
+                            Tokenizer.SCRIPT_DATA, lastStartTag);
                 } else {
                     throw new RuntimeException("Broken test data.");
                 }


### PR DESCRIPTION
This change ensures that `TokenizerTester` uses the correct, expected `lastStartTag` value from the test source when the `initialStates` value in the test source includes `Script data state` — or else if the test source specifies no `lastStartTag`, then `script` is used as the value.

Otherwise, without this change, `TokenizerTester` is hardcoded to always use `script` as the `lastStartTag` when running a test case with “Script data state” as the initial state. That discrepancy causes us to fail the following case from the html5lib-tests suite:

* https://github.com/html5lib/html5lib-tests/blob/master/tokenizer/domjs.test#L219-L223 (“lowercase endtags”)