### PR TITLE
Ensure namespace-aware “clear the stack” handling

### DIFF
--- a/src/nu/validator/htmlparser/impl/TreeBuilder.java
+++ b/src/nu/validator/htmlparser/impl/TreeBuilder.java
@@ -3898,8 +3898,9 @@ public abstract class TreeBuilder<T> implements TokenHandler,
 
     private int findLastInTableScopeOrRootTemplateTbodyTheadTfoot() {
         for (int i = currentPtr; i > 0; i--) {
-            if (stack[i].getGroup() == TreeBuilder.TBODY_OR_THEAD_OR_TFOOT ||
-                    stack[i].getGroup() == TreeBuilder.TEMPLATE) {
+            if (stack[i].ns == "http://www.w3.org/1999/xhtml"
+                    && (stack[i].getGroup() == TreeBuilder.TBODY_OR_THEAD_OR_TFOOT
+                            || stack[i].getGroup() == TreeBuilder.TEMPLATE)) {
                 return i;
             }
         }
@@ -4667,7 +4668,7 @@ public abstract class TreeBuilder<T> implements TokenHandler,
 
     private int findLastOrRoot(int group) {
         for (int i = currentPtr; i > 0; i--) {
-            if (stack[i].getGroup() == group) {
+            if (stack[i].ns == "http://www.w3.org/1999/xhtml" && stack[i].getGroup() == group) {
                 return i;
             }
         }


### PR DESCRIPTION
This change ensures that for all cases with spec requirements in the form “clear the stack back to a *foo* context” — which involves checking for elements with particular names — we only look for elements in the HTML namespace, rather than additionally looking for elements which aren’t in the HTML namespace but that also have those particular names.

Otherwise, without this change, we aren’t in conformance with the spec requirements, and we fail several cases in the html5lib-tests suite.

Fixes https://github.com/validator/htmlparser/issues/33

---

Without this change, we’re failing the following html5lib-tests fragment-parsing cases:

* https://github.com/html5lib/html5lib-tests/blob/master/tree-construction/math.dat#L13 `<math><tr><td><mo><tr>` context: tr
* https://github.com/html5lib/html5lib-tests/blob/master/tree-construction/math.dat#L24 `<math><thead><mo><tbody>` context: thead
* https://github.com/html5lib/html5lib-tests/blob/master/tree-construction/math.dat#L34 `<math><tfoot><mo><tbody>` context: tfoot
* https://github.com/html5lib/html5lib-tests/blob/master/tree-construction/math.dat#L44 `<math><tbody><mo><tfoot>` context: tbody

…and also failing the corresponding tests in https://github.com/html5lib/html5lib-tests/blob/master/tree-construction/svg.dat