### PR TITLE
Add test automation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        # See http://static.azul.com/zulu/bin/ for available JDK versions.
+        java: [8, 11, 14, 15-ea, 16-ea]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    name: Java ${{ matrix.java }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Set up java
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Build with Maven
+        run: mvn -B verify

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "test-src/test/resources/html5lib-tests"]
+	path = test-src/test/resources/html5lib-tests
+	url = git@github.com:html5lib/html5lib-tests.git

--- a/pom.xml
+++ b/pom.xml
@@ -80,8 +80,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>
@@ -136,7 +136,11 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <skip>true</skip>
+          <test>Html5libTest</test>
+          <testFailureIgnore>true</testFailureIgnore> <!-- FIXME: Remove this testFailureIgnore after we have all tests passing -->
+          <additionalClasspathElements>
+            <additionalClasspathElement>${project.build.testSourceDirectory}/test/resources</additionalClasspathElement>
+          </additionalClasspathElements>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -115,8 +115,12 @@
                 <property name="translator.sources" value="${basedir}/translator-src"/>
                 <property name="translator.classes" value="${project.build.directory}/translator-classes"/>
                 <mkdir dir="${translator.classes}"/>
-                <javac srcdir="${translator.sources}" includes="nu/validator/htmlparser/generator/ApplyHotSpotWorkaround.java" destdir="${translator.classes}" includeantruntime="false"/>
-                <java classname="nu.validator.htmlparser.generator.ApplyHotSpotWorkaround">
+                <javac srcdir="${translator.sources}" destdir="${translator.classes}"
+                       includes="nu/validator/htmlparser/generator/ApplyHotSpotWorkaround.java"
+                       includeantruntime="false"
+                       fork="${fork}"/>
+                <java classname="nu.validator.htmlparser.generator.ApplyHotSpotWorkaround"
+                      fork="${fork}">
                   <classpath>
                     <pathelement location="${translator.classes}"/>
                   </classpath>
@@ -227,6 +231,7 @@
     <rpm.java.dir>/usr/share/java</rpm.java.dir>
     <rpm.javadoc.dir>/usr/share/javadoc</rpm.javadoc.dir>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <fork>false</fork>
   </properties>
   <profiles>
     <profile>
@@ -234,6 +239,9 @@
       <activation>
         <jdk>1.8</jdk>
       </activation>
+      <properties>
+        <fork>true</fork>
+      </properties>
       <dependencies>
         <dependency>
           <groupId>com.sun</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -87,15 +87,6 @@
       <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
         <version>1.7</version>
-        <dependencies>
-          <dependency>
-            <groupId>com.sun</groupId>
-            <artifactId>tools</artifactId>
-            <version>1.5.0</version>
-            <scope>system</scope>
-            <systemPath>${java.home}/../lib/tools.jar</systemPath>
-          </dependency>
-        </dependencies>
         <executions>
           <execution>
             <id>intitialize-sources</id>
@@ -237,4 +228,21 @@
     <rpm.javadoc.dir>/usr/share/javadoc</rpm.javadoc.dir>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
+  <profiles>
+    <profile>
+      <id>Java 8</id>
+      <activation>
+        <jdk>1.8</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>com.sun</groupId>
+          <artifactId>tools</artifactId>
+          <version>1.5.0</version>
+          <scope>system</scope>
+          <systemPath>${java.home}/../lib/tools.jar</systemPath>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 </project>

--- a/test-src/nu/validator/htmlparser/test/EncodingTester.java
+++ b/test-src/nu/validator/htmlparser/test/EncodingTester.java
@@ -38,6 +38,8 @@ public class EncodingTester {
 
     private static int exitStatus = 0;
 
+    protected static int SNIFFING_LIMIT = 16384;
+
     private final InputStream aggregateStream;
 
     private final StringBuilder builder = new StringBuilder();
@@ -61,7 +63,7 @@ public class EncodingTester {
         }
         UntilHashInputStream stream = new UntilHashInputStream(aggregateStream);
         HtmlInputStreamReader reader = new HtmlInputStreamReader(stream, null,
-                null, null, Heuristics.NONE);
+                null, null, Heuristics.NONE, SNIFFING_LIMIT);
         Charset charset = reader.getCharset();
         stream.close();
         if (skipLabel()) {

--- a/test-src/nu/validator/htmlparser/test/EncodingTester.java
+++ b/test-src/nu/validator/htmlparser/test/EncodingTester.java
@@ -86,7 +86,6 @@ public class EncodingTester {
         String sniffed = charset.name();
         String expected = Encoding.forName(builder.toString()).newDecoder().charset().name();
         if (expected.equalsIgnoreCase(sniffed)) {
-            System.err.println("Success.");
             // System.err.println(stream);
         } else {
             exitStatus = 1;

--- a/test-src/nu/validator/htmlparser/test/EncodingTester.java
+++ b/test-src/nu/validator/htmlparser/test/EncodingTester.java
@@ -36,6 +36,8 @@ import org.xml.sax.SAXException;
 
 public class EncodingTester {
 
+    private static int exitStatus = 0;
+
     private final InputStream aggregateStream;
 
     private final StringBuilder builder = new StringBuilder();
@@ -63,6 +65,7 @@ public class EncodingTester {
         Charset charset = reader.getCharset();
         stream.close();
         if (skipLabel()) {
+            exitStatus = 1;
             System.err.println("Premature end of test data.");
             return false;
         }
@@ -73,6 +76,7 @@ public class EncodingTester {
                 case '\n':
                     break loop;
                 case -1:
+                    exitStatus = 1;
                     System.err.println("Premature end of test data.");
                     return false;
                 default:
@@ -85,6 +89,7 @@ public class EncodingTester {
             System.err.println("Success.");
             // System.err.println(stream);
         } else {
+            exitStatus = 1;
             System.err.println("Failure. Expected: " + expected + " got "
                     + sniffed + ".");
             System.err.println(stream);
@@ -118,6 +123,7 @@ public class EncodingTester {
                     args[i]));
             tester.runTests();
         }
+        System.exit(exitStatus);
     }
 
 }

--- a/test-src/nu/validator/htmlparser/test/EncodingTester.java
+++ b/test-src/nu/validator/htmlparser/test/EncodingTester.java
@@ -36,7 +36,7 @@ import org.xml.sax.SAXException;
 
 public class EncodingTester {
 
-    private static int exitStatus = 0;
+    static int exitStatus = 0;
 
     protected static int SNIFFING_LIMIT = 16384;
 
@@ -51,7 +51,7 @@ public class EncodingTester {
         this.aggregateStream = aggregateStream;
     }
 
-    private void runTests() throws IOException, SAXException {
+    void runTests() throws IOException, SAXException {
         while (runTest()) {
             // spin
         }

--- a/test-src/nu/validator/htmlparser/test/Html5libTest.java
+++ b/test-src/nu/validator/htmlparser/test/Html5libTest.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2020 Mozilla Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
 package nu.validator.htmlparser.test;
 
 import java.io.IOException;
@@ -14,26 +36,33 @@ public class Html5libTest {
     private final Path testDir;
 
     public Html5libTest() throws URISyntaxException {
-        this.testDir = Path.of(Html5libTest.class.getResource("/html5lib-tests").toURI());
+        this.testDir = Path.of(
+                Html5libTest.class.getResource("/html5lib-tests").toURI());
     }
 
     public void testEncoding() throws Exception {
-        Files.walkFileTree(testDir.resolve("encoding"), new TestVisitor(true, false, file -> new EncodingTester(Files.newInputStream(file)).runTests()));
-        if(EncodingTester.exitStatus != 0) {
+        Files.walkFileTree(testDir.resolve("encoding"), //
+                new TestVisitor(true, false, file -> //
+                new EncodingTester(Files.newInputStream(file)).runTests()));
+        if (EncodingTester.exitStatus != 0) {
             assert false : "Encoding test failed";
         }
     }
 
     public void testTokenizer() throws Exception {
-        Files.walkFileTree(testDir.resolve("tokenizer"), new TestVisitor(true, true, file -> new TokenizerTester(Files.newInputStream(file)).runTests()));
-        if(TokenizerTester.exitStatus != 0) {
+        Files.walkFileTree(testDir.resolve("tokenizer"),
+                new TestVisitor(true, true, file -> //
+                new TokenizerTester(Files.newInputStream(file)).runTests()));
+        if (TokenizerTester.exitStatus != 0) {
             assert false : "Tokenizer test failed";
         }
     }
 
     public void testTree() throws Exception {
-        Files.walkFileTree(testDir.resolve("tree-construction"), new TestVisitor(true, false, file -> new TreeTester(Files.newInputStream(file)).runTests()));
-        if(TreeTester.exitStatus != 0) {
+        Files.walkFileTree(testDir.resolve("tree-construction"),
+                new TestVisitor(true, false, file -> //
+                new TreeTester(Files.newInputStream(file)).runTests()));
+        if (TreeTester.exitStatus != 0) {
             assert false : "Tree test failed";
         }
     }
@@ -44,7 +73,7 @@ public class Html5libTest {
         default void accept(Path t) {
             try {
                 acceptTest(t);
-            } catch(Throwable e) {
+            } catch (Throwable e) {
                 throw new AssertionError(e);
             }
         }
@@ -56,17 +85,21 @@ public class Html5libTest {
     private static class TestVisitor extends SimpleFileVisitor<Path> {
 
         private final boolean skipScripted;
+
         private final boolean requireTestExtension;
+
         private final TestConsumer runner;
 
-        private TestVisitor(boolean skipScripted, boolean requireTestExtension, TestConsumer runner) {
+        private TestVisitor(boolean skipScripted, boolean requireTestExtension,
+                TestConsumer runner) {
             this.skipScripted = skipScripted;
             this.requireTestExtension = requireTestExtension;
             this.runner = runner;
         }
 
         @Override
-        public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+        public FileVisitResult preVisitDirectory(Path dir,
+                BasicFileAttributes attrs) throws IOException {
             if (skipScripted && dir.getFileName().equals(Path.of("scripted"))) {
                 return FileVisitResult.SKIP_SUBTREE;
             }
@@ -75,8 +108,10 @@ public class Html5libTest {
         }
 
         @Override
-        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-            if (!requireTestExtension || file.getFileName().toString().endsWith(".test")) {
+        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
+                throws IOException {
+            if (!requireTestExtension
+                    || file.getFileName().toString().endsWith(".test")) {
                 runner.accept(file);
             }
             return FileVisitResult.CONTINUE;

--- a/test-src/nu/validator/htmlparser/test/Html5libTest.java
+++ b/test-src/nu/validator/htmlparser/test/Html5libTest.java
@@ -22,8 +22,10 @@
 
 package nu.validator.htmlparser.test;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -52,7 +54,7 @@ public class Html5libTest {
     public void testTokenizer() throws Exception {
         Files.walkFileTree(testDir.resolve("tokenizer"),
                 new TestVisitor(true, ".test", file -> //
-                new TokenizerTester(Files.newInputStream(file)).runTests()));
+                new TokenizerTester(getDoubleEscapedInput(file)).runTests()));
         if (TokenizerTester.exitStatus != 0) {
             assert false : "Tokenizer test failed";
         }
@@ -65,6 +67,15 @@ public class Html5libTest {
         if (TreeTester.exitStatus != 0) {
             assert false : "Tree test failed";
         }
+    }
+
+    private ByteArrayInputStream getDoubleEscapedInput(Path file)
+            throws IOException {
+        byte[] fileBytes = Files.readAllBytes(file);
+        String fileContent = new String(fileBytes, StandardCharsets.UTF_8);
+        String unescapedContent = fileContent.replace("\\\\u", "\\u");
+        byte[] newBytes = unescapedContent.getBytes(StandardCharsets.UTF_8);
+        return new ByteArrayInputStream(newBytes);
     }
 
     private interface TestConsumer extends Consumer<Path> {

--- a/test-src/nu/validator/htmlparser/test/Html5libTest.java
+++ b/test-src/nu/validator/htmlparser/test/Html5libTest.java
@@ -42,7 +42,7 @@ public class Html5libTest {
 
     public void testEncoding() throws Exception {
         Files.walkFileTree(testDir.resolve("encoding"), //
-                new TestVisitor(true, false, file -> //
+                new TestVisitor(true, ".dat", file -> //
                 new EncodingTester(Files.newInputStream(file)).runTests()));
         if (EncodingTester.exitStatus != 0) {
             assert false : "Encoding test failed";
@@ -51,7 +51,7 @@ public class Html5libTest {
 
     public void testTokenizer() throws Exception {
         Files.walkFileTree(testDir.resolve("tokenizer"),
-                new TestVisitor(true, true, file -> //
+                new TestVisitor(true, ".test", file -> //
                 new TokenizerTester(Files.newInputStream(file)).runTests()));
         if (TokenizerTester.exitStatus != 0) {
             assert false : "Tokenizer test failed";
@@ -60,7 +60,7 @@ public class Html5libTest {
 
     public void testTree() throws Exception {
         Files.walkFileTree(testDir.resolve("tree-construction"),
-                new TestVisitor(true, false, file -> //
+                new TestVisitor(true, ".dat", file -> //
                 new TreeTester(Files.newInputStream(file)).runTests()));
         if (TreeTester.exitStatus != 0) {
             assert false : "Tree test failed";
@@ -86,14 +86,14 @@ public class Html5libTest {
 
         private final boolean skipScripted;
 
-        private final boolean requireTestExtension;
+        private final String requiredTestExtension;
 
         private final TestConsumer runner;
 
-        private TestVisitor(boolean skipScripted, boolean requireTestExtension,
+        private TestVisitor(boolean skipScripted, String requiredTestExtension,
                 TestConsumer runner) {
             this.skipScripted = skipScripted;
-            this.requireTestExtension = requireTestExtension;
+            this.requiredTestExtension = requiredTestExtension;
             this.runner = runner;
         }
 
@@ -110,8 +110,7 @@ public class Html5libTest {
         @Override
         public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
                 throws IOException {
-            if (!requireTestExtension
-                    || file.getFileName().toString().endsWith(".test")) {
+            if (file.getFileName().toString().endsWith(requiredTestExtension)) {
                 runner.accept(file);
             }
             return FileVisitResult.CONTINUE;

--- a/test-src/nu/validator/htmlparser/test/Html5libTest.java
+++ b/test-src/nu/validator/htmlparser/test/Html5libTest.java
@@ -1,0 +1,86 @@
+package nu.validator.htmlparser.test;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.function.Consumer;
+
+public class Html5libTest {
+
+    private final Path testDir;
+
+    public Html5libTest() throws URISyntaxException {
+        this.testDir = Path.of(Html5libTest.class.getResource("/html5lib-tests").toURI());
+    }
+
+    public void testEncoding() throws Exception {
+        Files.walkFileTree(testDir.resolve("encoding"), new TestVisitor(true, false, file -> new EncodingTester(Files.newInputStream(file)).runTests()));
+        if(EncodingTester.exitStatus != 0) {
+            assert false : "Encoding test failed";
+        }
+    }
+
+    public void testTokenizer() throws Exception {
+        Files.walkFileTree(testDir.resolve("tokenizer"), new TestVisitor(true, true, file -> new TokenizerTester(Files.newInputStream(file)).runTests()));
+        if(TokenizerTester.exitStatus != 0) {
+            assert false : "Tokenizer test failed";
+        }
+    }
+
+    public void testTree() throws Exception {
+        Files.walkFileTree(testDir.resolve("tree-construction"), new TestVisitor(true, false, file -> new TreeTester(Files.newInputStream(file)).runTests()));
+        if(TreeTester.exitStatus != 0) {
+            assert false : "Tree test failed";
+        }
+    }
+
+    private interface TestConsumer extends Consumer<Path> {
+
+        @Override
+        default void accept(Path t) {
+            try {
+                acceptTest(t);
+            } catch(Throwable e) {
+                throw new AssertionError(e);
+            }
+        }
+
+        void acceptTest(Path t) throws Throwable;
+
+    }
+
+    private static class TestVisitor extends SimpleFileVisitor<Path> {
+
+        private final boolean skipScripted;
+        private final boolean requireTestExtension;
+        private final TestConsumer runner;
+
+        private TestVisitor(boolean skipScripted, boolean requireTestExtension, TestConsumer runner) {
+            this.skipScripted = skipScripted;
+            this.requireTestExtension = requireTestExtension;
+            this.runner = runner;
+        }
+
+        @Override
+        public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+            if (skipScripted && dir.getFileName().equals(Path.of("scripted"))) {
+                return FileVisitResult.SKIP_SUBTREE;
+            }
+
+            return FileVisitResult.CONTINUE;
+        }
+
+        @Override
+        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+            if (!requireTestExtension || file.getFileName().toString().endsWith(".test")) {
+                runner.accept(file);
+            }
+            return FileVisitResult.CONTINUE;
+        }
+    }
+
+}

--- a/test-src/nu/validator/htmlparser/test/Html5libTest.java
+++ b/test-src/nu/validator/htmlparser/test/Html5libTest.java
@@ -29,6 +29,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.function.Consumer;
@@ -38,7 +39,7 @@ public class Html5libTest {
     private final Path testDir;
 
     public Html5libTest() throws URISyntaxException {
-        this.testDir = Path.of(
+        this.testDir = Paths.get(
                 Html5libTest.class.getResource("/html5lib-tests").toURI());
     }
 
@@ -111,7 +112,8 @@ public class Html5libTest {
         @Override
         public FileVisitResult preVisitDirectory(Path dir,
                 BasicFileAttributes attrs) throws IOException {
-            if (skipScripted && dir.getFileName().equals(Path.of("scripted"))) {
+            if (skipScripted
+                    && dir.getFileName().equals(Paths.get("scripted"))) {
                 return FileVisitResult.SKIP_SUBTREE;
             }
 

--- a/test-src/nu/validator/htmlparser/test/TokenizerTester.java
+++ b/test-src/nu/validator/htmlparser/test/TokenizerTester.java
@@ -181,9 +181,7 @@ public class TokenizerTester {
         try {
             driver.tokenize(is);
             JSONArray actualTokens = tokenHandler.getArray();
-            if (jsonDeepEquals(actualTokens, expectedTokens)) {
-                writer.write("Success\n");
-            } else {
+            if (!jsonDeepEquals(actualTokens, expectedTokens)) {
                 exitStatus = 1;
                 writer.write("Failure\n");
                 writer.write(description);

--- a/test-src/nu/validator/htmlparser/test/TokenizerTester.java
+++ b/test-src/nu/validator/htmlparser/test/TokenizerTester.java
@@ -97,7 +97,7 @@ public class TokenizerTester {
 
     private final Writer writer;
 
-    private TokenizerTester(InputStream stream) throws TokenStreamException,
+    public TokenizerTester(InputStream stream) throws TokenStreamException,
             RecognitionException, UnsupportedEncodingException {
         tokenHandler = new JSONArrayTokenHandler();
         driver = new Driver(new ErrorReportingTokenizer(tokenHandler));

--- a/test-src/nu/validator/htmlparser/test/TokenizerTester.java
+++ b/test-src/nu/validator/htmlparser/test/TokenizerTester.java
@@ -51,6 +51,8 @@ import com.sdicons.json.parser.JSONParser;
 
 public class TokenizerTester {
 
+    private static int exitStatus = 0;
+
     private static JSONString PLAINTEXT = new JSONString("PLAINTEXT state");
 
     private static JSONString PCDATA = new JSONString("Data state");
@@ -182,6 +184,7 @@ public class TokenizerTester {
             if (jsonDeepEquals(actualTokens, expectedTokens)) {
                 writer.write("Success\n");
             } else {
+                exitStatus = 1;
                 writer.write("Failure\n");
                 writer.write(description);
                 writer.write("\nInput:\n");
@@ -193,6 +196,7 @@ public class TokenizerTester {
                 writer.write("\n");
             }
         } catch (Throwable t) {
+            exitStatus = 1;
             writer.write("Failure\n");
             writer.write(description);
             writer.write("\nInput:\n");
@@ -216,6 +220,7 @@ public class TokenizerTester {
                     args[i]));
             tester.runTests();
         }
+        System.exit(exitStatus);
     }
 
 }

--- a/test-src/nu/validator/htmlparser/test/TokenizerTester.java
+++ b/test-src/nu/validator/htmlparser/test/TokenizerTester.java
@@ -51,7 +51,7 @@ import com.sdicons.json.parser.JSONParser;
 
 public class TokenizerTester {
 
-    private static int exitStatus = 0;
+    static int exitStatus = 0;
 
     private static JSONString PLAINTEXT = new JSONString("PLAINTEXT state");
 
@@ -121,7 +121,7 @@ public class TokenizerTester {
         }
     }
 
-    private void runTests() throws SAXException, IOException {
+    void runTests() throws SAXException, IOException {
         for (JSONValue val : tests.getValue()) {
             runTest((JSONObject) val);
         }

--- a/test-src/nu/validator/htmlparser/test/TokenizerTester.java
+++ b/test-src/nu/validator/htmlparser/test/TokenizerTester.java
@@ -53,7 +53,7 @@ public class TokenizerTester {
 
     private static JSONString PLAINTEXT = new JSONString("PLAINTEXT state");
 
-    private static JSONString PCDATA = new JSONString("DATA state");
+    private static JSONString PCDATA = new JSONString("Data state");
 
     private static JSONString RCDATA = new JSONString("RCDATA state");
 

--- a/test-src/nu/validator/htmlparser/test/TreeTester.java
+++ b/test-src/nu/validator/htmlparser/test/TreeTester.java
@@ -223,7 +223,6 @@ public class TreeTester {
              * && expectedErrors.size() ==
              * actualErrors.size()
              */) {
-                System.err.println("Success.");
                 // System.err.println(stream);
             } else {
                 exitStatus = 1;

--- a/test-src/nu/validator/htmlparser/test/TreeTester.java
+++ b/test-src/nu/validator/htmlparser/test/TreeTester.java
@@ -43,7 +43,7 @@ public class TreeTester {
 
     private boolean streaming = false;
 
-    private static int exitStatus = 0;
+    static int exitStatus = 0;
 
     /**
      * @param aggregateStream
@@ -52,7 +52,7 @@ public class TreeTester {
         this.aggregateStream = new BufferedInputStream(aggregateStream);
     }
 
-    private void runTests() throws Throwable {
+    void runTests() throws Throwable {
         if (aggregateStream.read() != '#') {
             System.err.println("No hash at start!");
             return;

--- a/test-src/nu/validator/htmlparser/test/TreeTester.java
+++ b/test-src/nu/validator/htmlparser/test/TreeTester.java
@@ -43,6 +43,8 @@ public class TreeTester {
 
     private boolean streaming = false;
 
+    private static int exitStatus = 0;
+
     /**
      * @param aggregateStream
      */
@@ -224,6 +226,7 @@ public class TreeTester {
                 System.err.println("Success.");
                 // System.err.println(stream);
             } else {
+                exitStatus = 1;
                 System.err.print("Failure.\nData:\n" + stream + "\nExpected:\n"
                         + expected + "Got: \n" + actual);
                 System.err.println("Expected errors:");
@@ -236,6 +239,7 @@ public class TreeTester {
                 }
             }
         } catch (Throwable t) {
+            exitStatus = 1;
             System.err.println("Failure.\nData:\n" + stream);
             throw t;
         }
@@ -266,6 +270,7 @@ public class TreeTester {
             TreeTester tester = new TreeTester(new FileInputStream(args[i]));
             tester.runTests();
         }
+        System.exit(exitStatus);
     }
 
 }


### PR DESCRIPTION
The changes in this pull-request branch enable us, for all pull requests and pushes, to automate testing of the parser against the html5lib-tests suite — including CI execution (using GitHub Actions) of the tests .

The changes include the following commits:

* 15955c02862815b4c131775e4d33cd47504c2c97 Add Html5libTest
* c1c10352061a8f9026a865995ebe4332ede5ecb0 Add html5lib-tests as a submodule
* ff468880d64187ca02213b7a495ac0a73cbdb22d Add GitHub Actions build.yml to run Maven in CI
* 419cae541fae5e3b4ca6caa1deec58564d69b157 Exit 1 for test harness if any tests fail
* 2dcd4da054e5c21a7ae59c77848be385cda7a6d6 Make Html5libTest handle double-escaped tests
* 27c5068fa07e81e89f943878a14f62bc56e1f50a Make Html5libTest only check .dat and .test files
* 500a9f5387f792055c5864a0eee6547c318a8cb1 Make EncodingTester usable in testing parsed state (from PR #49)
* 8d31a0b460c16f016c74bbaedbc5404aa3b59f1c Make HtmlInputStreamReader sniffing limit settable (from PR #49)

…along with some related minor changes to get things working smoothly.