### PR TITLE
increase bufferSpace by at least 25%

### DIFF
--- a/src/nu/validator/htmlparser/impl/Tokenizer.java
+++ b/src/nu/validator/htmlparser/impl/Tokenizer.java
@@ -1463,7 +1463,7 @@ public class Tokenizer implements Locator, Locator2 {
             // but not doing that without profiling. In C++ with jemalloc,
             // the corresponding method should do math to round up here
             // to avoid slop.
-            char[] newBuf = new char[worstCase];
+            char[] newBuf = new char[Math.max(worstCase, (strBuf.length*5)/4)];
             System.arraycopy(strBuf, 0, newBuf, 0, strBufLen);
             strBuf = newBuf;
         }


### PR DESCRIPTION
to remedy an O(n^2) performance problem when parsing e.g. inline images.

The performance problem is noticeable for e.g. `<img src=\"data:image/png;base64,iVBORw0KGgoAAAA...` when the image has a size of  multiple megabytes. An incremental increase of some KBs each does not help much, thus this PR increases by a proportional factor of 25%. 