### PR TITLE
Mozilla bug 1775477 - Fix parser-created keygen element interface.

### DIFF
--- a/src/nu/validator/htmlparser/impl/ElementName.java
+++ b/src/nu/validator/htmlparser/impl/ElementName.java
@@ -1166,7 +1166,7 @@ public static final ElementName MN = new ElementName("mn", "mn",
 // CPPONLY: NS_NewSVGUnknownElement, 
 TreeBuilder.MI_MO_MN_MS_MTEXT | SCOPING_AS_MATHML);
 public static final ElementName KEYGEN = new ElementName("keygen", "keygen", 
-// CPPONLY: NS_NewHTMLElement,
+// CPPONLY: NS_NewHTMLUnknownElement,
 // CPPONLY: NS_NewSVGUnknownElement, 
 TreeBuilder.KEYGEN | SPECIAL);
 public static final ElementName MAIN = new ElementName("main", "main", 


### PR DESCRIPTION
This basically undoes the manual change from https://github.com/validator/htmlparser/pull/70.