### PR TITLE
Streamline the warning about self-closing-tag syntax

### DIFF
--- a/src/nu/validator/htmlparser/impl/TreeBuilder.java
+++ b/src/nu/validator/htmlparser/impl/TreeBuilder.java
@@ -2889,9 +2889,8 @@ public abstract class TreeBuilder<T> implements TokenHandler,
         } else if (wasSelfClosing && voidElement
                 && tokenizer.getErrorProfile() != null
                 && tokenizer.getErrorProfile().get("html-strict") != null) {
-            warn("Void elements cannot be marked as self-closing. Closing"
-                    + " slashes in void-element start tags are unnecessary and"
-                    + " interact badly with unquoted attribute values.");
+            warn("Trailing slash on void elements has no effect and interacts"
+                    + " badly with unquoted attribute values.");
         // ]NOCPP]
         }
         // CPPONLY: if (mBuilder == null && attributes != HtmlAttributes.EMPTY_ATTRIBUTES) {

--- a/src/nu/validator/htmlparser/impl/TreeBuilder.java
+++ b/src/nu/validator/htmlparser/impl/TreeBuilder.java
@@ -2889,13 +2889,9 @@ public abstract class TreeBuilder<T> implements TokenHandler,
         } else if (wasSelfClosing && voidElement
                 && tokenizer.getErrorProfile() != null
                 && tokenizer.getErrorProfile().get("html-strict") != null) {
-            warn("Self-closing tag syntax in text/html documents is widely"
-                    + " discouraged; it’s unnecessary and interacts badly"
-                    + " with other HTML features (e.g., unquoted attribute"
-                    + " values). If you’re using a tool that injects"
-                    + " self-closing tag syntax into all void elements,"
-                    + " without any option to prevent it from doing so,"
-                    + " then consider switching to a different tool.");
+            warn("Void elements cannot be marked as self-closing. Closing"
+                    + " slashes in void-element start tags are unnecessary and"
+                    + " interact badly with unquoted attribute values.");
         // ]NOCPP]
         }
         // CPPONLY: if (mBuilder == null && attributes != HtmlAttributes.EMPTY_ATTRIBUTES) {


### PR DESCRIPTION
“widely discouraged” is subjective; and regardless, what’s actually relevant is what the spec states — so let’s focus the warning into closer alignment just with what the spec states, which is:

> On void elements, [the solidus] does not mark the start tag as self-closing but instead is unnecessary and has no effect of any kind. For such void elements, it should be used only with caution — especially since, if directly preceded by an unquoted attribute value, it becomes part of the attribute value rather than being discarded by the parser.

Further, we don’t really need the statement about considering to switch tools; it makes the message longer than it needs to be.