### PR TITLE
Make trailing-slash-on-void-elements message not depend on profile code

### DIFF
--- a/src/nu/validator/htmlparser/impl/ErrorReportingTokenizer.java
+++ b/src/nu/validator/htmlparser/impl/ErrorReportingTokenizer.java
@@ -135,15 +135,6 @@ public class ErrorReportingTokenizer extends Tokenizer {
     }
 
     /**
-     * Gets the errorProfile.
-     *
-     * @param errorProfile
-     */
-    @Override public HashMap getErrorProfile() {
-        return errorProfileMap;
-    }
-
-    /**
      * Reports on an event based on profile selected.
      *
      * @param profile

--- a/src/nu/validator/htmlparser/impl/Tokenizer.java
+++ b/src/nu/validator/htmlparser/impl/Tokenizer.java
@@ -35,8 +35,6 @@
 
 package nu.validator.htmlparser.impl;
 
-import java.util.HashMap;
-
 import org.xml.sax.ErrorHandler;
 import org.xml.sax.Locator;
 import org.xml.sax.ext.Locator2;
@@ -686,15 +684,6 @@ public class Tokenizer implements Locator, Locator2 {
 
     public ErrorHandler getErrorHandler() {
         return this.errorHandler;
-    }
-
-    /**
-     * Gets the errorProfile.
-     *
-     * @param errorProfile
-     */
-    public HashMap getErrorProfile() {
-        return null;
     }
 
     /**

--- a/src/nu/validator/htmlparser/impl/TreeBuilder.java
+++ b/src/nu/validator/htmlparser/impl/TreeBuilder.java
@@ -2886,9 +2886,7 @@ public abstract class TreeBuilder<T> implements TokenHandler,
         if (selfClosing) {
             errSelfClosing();
         // [NOCPP[
-        } else if (wasSelfClosing && voidElement
-                && tokenizer.getErrorProfile() != null
-                && tokenizer.getErrorProfile().get("html-strict") != null) {
+        } else if (wasSelfClosing && voidElement) {
             warn("Trailing slash on void elements has no effect and interacts"
                     + " badly with unquoted attribute values.");
         // ]NOCPP]


### PR DESCRIPTION
We probably want to remove `errorProfileMap` and all its related stuff in the tokenizer code, since there’s no evidence it’s used by anybody anywhere in any consumer code except for what’s in the checker code, and there’s no evidence that anybody’s using that feature (which has no associated UI and but instead depends on passing in a query param).

Given all that, it seems imprudent to yoke the trailing-slash-on-void-elements message behavior to that likely-to-be-removed `errorProfileMap` code. 