### PR TITLE
Mozilla bug 1857221 - Avoid tracking the line and column number when parsing innerHTML.

### DIFF
--- a/src/nu/validator/htmlparser/impl/Tokenizer.java
+++ b/src/nu/validator/htmlparser/impl/Tokenizer.java
@@ -1401,9 +1401,19 @@ public class Tokenizer implements Locator, Locator2 {
     public void start() throws SAXException {
         initializeWithoutStarting();
         tokenHandler.startTokenization(this);
-        // CPPONLY: line = 0;
-        // CPPONLY: col = 1;
-        // CPPONLY: nextCharOnNewLine = true;
+        // CPPONLY: if (mViewSource) {
+        // CPPONLY:   line = 1;
+        // CPPONLY:   col = -1;
+        // CPPONLY:   nextCharOnNewLine = false;
+        // CPPONLY: } else if (tokenHandler.WantsLineAndColumn()) {
+        // CPPONLY:   line = 0;
+        // CPPONLY:   col = 1;
+        // CPPONLY:   nextCharOnNewLine = true;
+        // CPPONLY: } else {
+        // CPPONLY:   line = -1;
+        // CPPONLY:   col = -1;
+        // CPPONLY:   nextCharOnNewLine = false;
+        // CPPONLY: }
         // [NOCPP[
         startErrorReporting();
         // ]NOCPP]
@@ -1469,6 +1479,8 @@ public class Tokenizer implements Locator, Locator2 {
         // CPPONLY:   mViewSource.SetBuffer(buffer);
         // CPPONLY:   pos = stateLoop(state, c, pos, buffer.getBuffer(), false, returnState, buffer.getEnd());
         // CPPONLY:   mViewSource.DropBuffer((pos == buffer.getEnd()) ? pos : pos + 1);
+        // CPPONLY: } else if (tokenHandler.WantsLineAndColumn()) {
+        // CPPONLY:   pos = stateLoop(state, c, pos, buffer.getBuffer(), false, returnState, buffer.getEnd());
         // CPPONLY: } else {
         // CPPONLY:   pos = stateLoop(state, c, pos, buffer.getBuffer(), false, returnState, buffer.getEnd());
         // CPPONLY: }
@@ -6320,24 +6332,24 @@ public class Tokenizer implements Locator, Locator2 {
         forceQuirks = false;
     }
 
-    @Inline private void adjustDoubleHyphenAndAppendToStrBufCarriageReturn()
+    private void adjustDoubleHyphenAndAppendToStrBufCarriageReturn()
             throws SAXException {
         silentCarriageReturn();
         adjustDoubleHyphenAndAppendToStrBufAndErr('\n', false);
     }
 
-    @Inline private void adjustDoubleHyphenAndAppendToStrBufLineFeed()
+    private void adjustDoubleHyphenAndAppendToStrBufLineFeed()
             throws SAXException {
         silentLineFeed();
         adjustDoubleHyphenAndAppendToStrBufAndErr('\n', false);
     }
 
-    @Inline private void appendStrBufLineFeed() {
+    private void appendStrBufLineFeed() {
         silentLineFeed();
         appendStrBuf('\n');
     }
 
-    @Inline private void appendStrBufCarriageReturn() {
+    private void appendStrBufCarriageReturn() {
         silentCarriageReturn();
         appendStrBuf('\n');
     }

--- a/translator-src/nu/validator/htmlparser/cpptranslate/CppTypes.java
+++ b/translator-src/nu/validator/htmlparser/cpptranslate/CppTypes.java
@@ -96,7 +96,7 @@ public class CppTypes {
             "nsHtml5ArrayCopy", "nsHtml5AtomTable", "nsHtml5DocumentMode",
             "nsHtml5Highlighter", "nsHtml5Macros", "nsHtml5NamedCharacters",
             "nsHtml5NamedCharactersAccel", "nsHtml5String",
-            "nsHtml5TokenizerLoopPolicies", "nsIContent", "nsTraceRefcnt" };
+            "nsIContent", "nsTraceRefcnt" };
 
     private static final String[] STACK_NODE_INCLUDES = { "nsAtom", "nsHtml5AtomTable",
             "nsHtml5HtmlAttributes", "nsHtml5String", "nsNameSpaceManager", "nsIContent",
@@ -125,7 +125,7 @@ public class CppTypes {
             "Tokenizer", "TreeBuilder", "UTF16Buffer", };
 
     private static final String[] STATE_LOOP_POLICIES = {
-            "nsHtml5ViewSourcePolicy", "nsHtml5SilentPolicy" };
+            "nsHtml5ViewSourcePolicy", "nsHtml5LineColPolicy", "nsHtml5FastestPolicy" };
 
     private final Map<String, String> atomMap = new HashMap<String, String>();
 
@@ -394,6 +394,17 @@ public class CppTypes {
     public String[] boilerplateForwardDeclarations() {
         return FORWARD_DECLARATIONS;
     }
+    
+    public boolean requiresTemplateParameter(String methodName) {
+        return "stateLoop".equals(methodName)
+                || "adjustDoubleHyphenAndAppendToStrBufCarriageReturn".equals(
+                        methodName)
+                || "adjustDoubleHyphenAndAppendToStrBufLineFeed".equals(
+                        methodName)
+                || "appendStrBufLineFeed".equals(methodName)
+                || "appendStrBufCarriageReturn".equals(methodName)
+                || "emitCarriageReturn".equals(methodName);
+    }
 
     public String documentModeHandlerType() {
         return "nsHtml5TreeBuilder*";
@@ -467,6 +478,18 @@ public class CppTypes {
         return "P::transition";
     }
 
+    public String checkChar() {
+        return "P::checkChar";
+    }
+
+    public String silentLineFeed() {
+        return "P::silentLineFeed";
+    }
+    
+    public String silentCarriageReturn() {
+        return "P::silentCarriageReturn";
+    }
+    
     public String tokenizerErrorCondition() {
         return "P::reportErrors";
     }
@@ -501,5 +524,9 @@ public class CppTypes {
 
     public String crashMacro() {
         return "MOZ_CRASH";
+    }
+    
+    public String loopPolicyInclude() {
+     return "nsHtml5TokenizerLoopPolicies";
     }
 }


### PR DESCRIPTION
Differential Revision: https://phabricator.services.mozilla.com/D191270