### PR TITLE
Prevent NPE in HtmlAttributes.getIndex

### DIFF
--- a/src/nu/validator/htmlparser/impl/HtmlAttributes.java
+++ b/src/nu/validator/htmlparser/impl/HtmlAttributes.java
@@ -184,7 +184,8 @@ public final class HtmlAttributes implements Attributes {
 
     public int getIndex(String qName) {
         for (int i = 0; i < length; i++) {
-            if (names[i].getQName(mode).equals(qName)) {
+            if (names[i].getQName(mode) != null &&
+                    names[i].getQName(mode).equals(qName)) {
                 return i;
             }
         }


### PR DESCRIPTION
Apparently it’s possible for a `mode` value to be such that `AttributeName.getQName(mode)` returns null. So this change adds a null check to catch that.

Otherwise, without this change, some documents cause that code to throw a NullPointerException.

The NullPointerException is reproducible by parsing the document at https://usbliss.com/?attachment_id=2232 — or by giving that document to the https://validator.w3.org/nu/ checker to check:

https://validator.w3.org/nu/?doc=https://usbliss.com/?attachment_id=2232

That causes the checker to emit the following message:

> Internal Error: Oops. That was not supposed to happen. A bug manifested itself in the application internals. Unable to continue. Sorry. The admin was notified.

(The admin who gets notified is me, and notification I get is a stack trace pointing to the NPE inHtmlAttributes.getIndex.)