### PR TITLE
Replace ICU4J UCharacter methods with standard Java Character class

### DIFF
--- a/src/nu/validator/htmlparser/extra/NormalizationChecker.java
+++ b/src/nu/validator/htmlparser/extra/NormalizationChecker.java
@@ -30,7 +30,6 @@ import org.xml.sax.Locator;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 
-import com.ibm.icu.lang.UCharacter;
 import com.ibm.icu.text.Normalizer;
 import com.ibm.icu.text.UnicodeSet;
 
@@ -103,7 +102,7 @@ public final class NormalizationChecker implements CharacterHandler {
      * or a surrogate and <code>false</code> otherwise
      */
     private static boolean isComposingCharOrSurrogate(char c) {
-        if (UCharacter.isHighSurrogate(c) || UCharacter.isLowSurrogate(c)) {
+        if (Character.isHighSurrogate(c) || Character.isLowSurrogate(c)) {
             return true;
         }
         return isComposingChar(c);
@@ -153,18 +152,18 @@ public final class NormalizationChecker implements CharacterHandler {
             char c = ch[start];
             if (pos == 1) {
                 // there's a single high surrogate in buf
-                if (isComposingChar(UCharacter.getCodePoint(buf[0], c))) {
+                if (isComposingChar(Character.toCodePoint(buf[0], c))) {
                     err("Text run starts with a composing character.");
                 }
                 atStartOfRun = false;
             } else {
-                if (length == 1 && UCharacter.isHighSurrogate(c)) {
+                if (length == 1 && Character.isHighSurrogate(c)) {
                     buf[0] = c;
                     pos = 1;
                     return;
                 } else {
-                    if (UCharacter.isHighSurrogate(c)) {
-                        if (isComposingChar(UCharacter.getCodePoint(c,
+                    if (Character.isHighSurrogate(c)) {
+                        if (isComposingChar(Character.toCodePoint(c,
                                 ch[start + 1]))) {
                             err("Text run starts with a composing character.");
                         }


### PR DESCRIPTION
ICU4J 75.1 removed the char-taking overloads of UCharacter methods:

- isHighSurrogate(char)    — removed (only isHighSurrogate(int) remains)
- isLowSurrogate(char)     — removed (only isLowSurrogate(int) remains)
- getCodePoint(char, char) — removed (only getCodePoint(int, int) remains)

When code compiled against an older ICU4J (which had those methods) runs with ICU4J 75.1, it throws NoSuchMethodError — because the bytecode contains direct references to the removed method signatures.

Note: Code compiled against ICU4J 75.1 happens to work because Java’s implicit widening conversion (char → int) binds to the int versions at compile time. But that doesn’t help users of pre-compiled artifacts.

This change replaces all uses of those ICU4J methods with equivalent methods from Java’s standard Character class (available since Java 5):

- UCharacter.isHighSurrogate(c)   → Character.isHighSurrogate(c)
- UCharacter.isLowSurrogate(c)    → Character.isLowSurrogate(c)
- UCharacter.getCodePoint(c1, c2) → Character.toCodePoint(c1, c2)