### PR TITLE
ensure mode is always set to INITIAL during startTokenization

### DIFF
--- a/src/nu/validator/htmlparser/impl/TreeBuilder.java
+++ b/src/nu/validator/htmlparser/impl/TreeBuilder.java
@@ -592,6 +592,7 @@ public abstract class TreeBuilder<T> implements TokenHandler,
         templateModeStack = new int[64];
         listOfActiveFormattingElements = new StackNode[64];
         needToDropLF = false;
+        mode = INITIAL;
         originalMode = INITIAL;
         templateModePtr = -1;
         stackNodesIdx = 0;


### PR DESCRIPTION
While currently, all branches set a mode, this is both subtle and fragile; if a branch ends up not setting mode it will never be reset. This means subsequent calls to start tokenisation can end up with a different initial mode.

This change simply resets mode to INITIAL on every startTokenization() call, ensuring that if we ever miss it, it will be reset.