### PR TITLE
Ignore inputs inside a `select` fragment context.

### DIFF
--- a/src/nu/validator/htmlparser/impl/TreeBuilder.java
+++ b/src/nu/validator/htmlparser/impl/TreeBuilder.java
@@ -2203,6 +2203,12 @@ public abstract class TreeBuilder<T> implements TokenHandler,
                             case INPUT:
                                 // https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inbody
                                 // "A start tag whose tag name is "input""
+                                // "If the parser was created as part of the HTML fragment
+                                //  parsing algorithm and the context element is a select element:"
+                                if (fragment && "select" == contextName) {
+                                    errStartTagWithSelectOpen(name);
+                                    break starttagloop;
+                                }
                                 // "If the stack of open elements has a select element
                                 //  in scope:"
                                 eltPos = findLastInScope("select");


### PR DESCRIPTION
This change does two things:

- updates the html5lib-tests, which exposes a failure in the current parser: it's missing the spec steps to ignore `<input>` when inside of a `<select>` during fragment parsing.
- subsequently fixes the failing test by adding the logic to ignore `<input>` inside of `<select>` during fragment parsing.

Refs https://github.com/html5lib/html5lib-tests/pull/195
