### PR TITLE
fix: Don’t report errors for omissible </option> end tag

### DIFF
--- a/src/nu/validator/htmlparser/impl/TreeBuilder.java
+++ b/src/nu/validator/htmlparser/impl/TreeBuilder.java
@@ -3704,7 +3704,7 @@ public abstract class TreeBuilder<T> implements TokenHandler,
                             for (;;) {
                                 StackNode<T> node = stack[eltPos];
                                 if (node.ns == "http://www.w3.org/1999/xhtml" && node.name == name) {
-                                    generateImpliedEndTags();
+                                    generateImpliedEndTagsExceptFor(name);
                                     if (errorHandler != null
                                             && !isCurrent(name)) {
                                         errUnclosedElements(eltPos, name);


### PR DESCRIPTION
**Problem:** We unexpectedly reported errors for omitted `</option>` end tags in cases where the spec allows omitting them. See https://github.com/validator/validator/issues/2116.

**Cause:** The spec’s _“any other end tag”_ case for the _“in body”_ insertion mode requires generating implied end tags _“except for HTML elements with the same tag name as the token”_. But we didn’t implement that exception. Specifically, we called `generateImpliedEndTags()` if tag name is `"option"` but should instead call `generateImpliedEndTagsExceptFor("option")`.

**Fix:** Call `generateImpliedEndTagsExceptFor("option")` instead.

